### PR TITLE
8276988: riscv: Fix a register name string: lr to x5

### DIFF
--- a/src/hotspot/cpu/riscv/register_riscv.cpp
+++ b/src/hotspot/cpu/riscv/register_riscv.cpp
@@ -39,7 +39,7 @@ const int ConcreteRegisterImpl::max_vpr =
 
 const char* RegisterImpl::name() const {
   const char* names[number_of_registers] = {
-    "zr", "ra", "sp", "gp", "tp", "lr", "x6", "x7", "fp", "x9",
+    "zr", "ra", "sp", "gp", "tp", "x5", "x6", "x7", "fp", "x9",
     "c_rarg0", "c_rarg1", "c_rarg2", "c_rarg3", "c_rarg4", "c_rarg5", "c_rarg6", "c_rarg7",
     "x18", "x19", "esp", "xdispatch", "xbcp", "xthread", "xlocals",
     "xmonitors", "xcpool", "xheapbase", "x28", "x29", "x30", "xmethod"


### PR DESCRIPTION
Hi team -

Simply fix a register name string: `lr` is `names[1]` so `names[5]` should be `x5`.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276988](https://bugs.openjdk.java.net/browse/JDK-8276988): riscv: Fix a register name string: lr to x5


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/2.diff">https://git.openjdk.java.net/riscv-port/pull/2.diff</a>

</details>
