### PR TITLE
8276989: riscv: C1 should not allocate x3, which is the gp register

### DIFF
--- a/src/hotspot/cpu/riscv/c1_Defs_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_Defs_riscv.hpp
@@ -43,11 +43,11 @@ enum {
   pd_nof_fpu_regs_frame_map = FloatRegisterImpl::number_of_registers,  // number of float registers used during code emission
 
   // caller saved
-  pd_nof_caller_save_cpu_regs_frame_map = 14, // number of registers killed by calls
+  pd_nof_caller_save_cpu_regs_frame_map = 13, // number of registers killed by calls
   pd_nof_caller_save_fpu_regs_frame_map = 32, // number of float registers killed by calls
 
   pd_first_callee_saved_reg = pd_nof_caller_save_cpu_regs_frame_map,
-  pd_last_callee_saved_reg = 22,
+  pd_last_callee_saved_reg = 21,
 
   pd_last_allocatable_cpu_reg = pd_nof_caller_save_cpu_regs_frame_map - 1,
 

--- a/src/hotspot/cpu/riscv/c1_FrameMap_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_FrameMap_riscv.cpp
@@ -181,6 +181,7 @@ LIR_Opr FrameMap::_caller_save_fpu_regs[] = { 0, };
 // |---x23--|
 // |---x8---|
 // |---x4---|
+// |---x3---|
 // |---x2---|
 // |---x1---|
 // |---x0---|
@@ -195,7 +196,6 @@ LIR_Opr FrameMap::_caller_save_fpu_regs[] = { 0, };
 // |---..---|
 // |---x10--|
 // |---x7---|
-// |---x3---|
 
 void FrameMap::initialize() {
   assert(!_init_done, "once");
@@ -203,7 +203,6 @@ void FrameMap::initialize() {
   int i = 0;
 
   // caller save register
-  map_register(i, x3);  r3_opr  = LIR_OprFact::single_cpu(i); i++;
   map_register(i, x7);  r7_opr  = LIR_OprFact::single_cpu(i); i++;
   map_register(i, x10); r10_opr = LIR_OprFact::single_cpu(i); i++;
   map_register(i, x11); r11_opr = LIR_OprFact::single_cpu(i); i++;
@@ -233,6 +232,7 @@ void FrameMap::initialize() {
   map_register(i, x0);  zr_opr  = LIR_OprFact::single_cpu(i); i++;  // zr
   map_register(i, x1);  r1_opr  = LIR_OprFact::single_cpu(i); i++;  // lr
   map_register(i, x2);  r2_opr  = LIR_OprFact::single_cpu(i); i++;  // sp
+  map_register(i, x3);  r3_opr  = LIR_OprFact::single_cpu(i); i++;  // gp
   map_register(i, x4);  r4_opr  = LIR_OprFact::single_cpu(i); i++;  // thread
   map_register(i, x8);  r8_opr  = LIR_OprFact::single_cpu(i); i++;  // fp
   map_register(i, x23); r23_opr = LIR_OprFact::single_cpu(i); i++;  // java thread
@@ -254,7 +254,6 @@ void FrameMap::initialize() {
   fpu10_double_opr  = LIR_OprFact::double_fpu(10);
 
   i = 0;
-  _caller_save_cpu_regs[i++]  = r3_opr;
   _caller_save_cpu_regs[i++]  = r7_opr;
   _caller_save_cpu_regs[i++]  = r10_opr;
   _caller_save_cpu_regs[i++]  = r11_opr;

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -260,7 +260,7 @@ static OopMap* generate_oop_map(StubAssembler* sasm, bool save_fpu_registers) {
 
   // cpu_regs, caller save registers only, see FrameMap::initialize
   // in c1_FrameMap_riscv64.cpp for detail.
-  const static Register caller_save_cpu_regs[FrameMap::max_nof_caller_save_cpu_regs] = {x3, x7, x10, x11, x12,
+  const static Register caller_save_cpu_regs[FrameMap::max_nof_caller_save_cpu_regs] = {x7, x10, x11, x12,
                                                                                         x13, x14, x15, x16, x17,
                                                                                         x28,  x29, x30, x31};
   for (int i = 0; i < FrameMap::max_nof_caller_save_cpu_regs; i++) {


### PR DESCRIPTION
Hi team,

x3 is a special register on RISCV and we should not use it as a register allocation candidate - if users write JNI programs referencing global variables, where ld could link global reference loading logic to an instruction like 'ld $Rtmp, $offset(x3)', and try to call vm functions, C1 will zap x3's value and causes a crash. It seems C2 doesn't use x3 so we are just aligning the logic with C2 properly.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276989](https://bugs.openjdk.java.net/browse/JDK-8276989): riscv: C1 should not allocate x3, which is the gp register


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - Committer)
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/3.diff">https://git.openjdk.java.net/riscv-port/pull/3.diff</a>

</details>
