### PR TITLE
8277391: riscv: Remove the USE_LIBRARY_BASED_TLS_ONLY macro to use tls instead of pthread_getspecific

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2720,19 +2720,18 @@ void MacroAssembler::eden_allocate(Register obj,
 // get_thread() can be called anywhere inside generated code so we
 // need to save whatever non-callee save context might get clobbered
 // by the call to Thread::current() or, indeed, the call setup code.
-//
-// FIXME: RISC-V does not yet support TLSDESC (Thread-Local Storage
-// Descriptors), once supported, we should repalce Thread::current
-// with JavaThread::riscv64_get_thread_helper() to reduce the clbber
-// of non-callee save context.
 void MacroAssembler::get_thread(Register thread) {
   // save all call-clobbered regs except thread
   RegSet saved_regs = RegSet::range(x5, x7) + RegSet::range(x10, x17) +
                       RegSet::range(x28, x31) + ra - thread;
   push_reg(saved_regs, sp);
 
-  call_VM_leaf_base(CAST_FROM_FN_PTR(address, Thread::current), 0);
-  mv(thread, x10); // x10 is function call_vm_leaf_base return value, return java_thread value.
+  int32_t offset = 0;
+  movptr_with_offset(ra, CAST_FROM_FN_PTR(address, Thread::current), offset);
+  jalr(ra, ra, offset);
+  if (thread != x10) {
+    mv(thread, x10);
+  }
 
   // restore pushed registers
   pop_reg(saved_regs, sp);

--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
@@ -165,9 +165,4 @@ inline int wcslen(const jchar* x) { return wcslen((const wchar_t*)x); }
 //
 #define ATTRIBUTE_ALIGNED(x) __attribute__((aligned(x)))
 
-// TODO: Implement JavaThread::riscv64_get_thread_helper and revert this change
-#if defined(RISCV)
-#define USE_LIBRARY_BASED_TLS_ONLY 1
-#endif
-
 #endif // SHARE_UTILITIES_GLOBALDEFINITIONS_GCC_HPP


### PR DESCRIPTION
Hi team,

This patch removes the USE_LIBRARY_BASED_TLS_ONLY macro to use tls instead of pthread_getspecific. [Original patch](https://github.com/riscv-collab/riscv-openjdk/pull/4)

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277391](https://bugs.openjdk.java.net/browse/JDK-8277391): riscv: Remove the USE_LIBRARY_BASED_TLS_ONLY macro to use tls instead of pthread_getspecific


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/7.diff">https://git.openjdk.java.net/riscv-port/pull/7.diff</a>

</details>
