### PR TITLE
8277392: riscv: Port missing trampoline logic from AArch64 platform

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -147,8 +147,12 @@ void NativeCall::set_destination_mt_safe(address dest, bool assert_lock) {
   }
 
   // Patch the call.
-  guarantee(trampoline_stub_addr != NULL, "we need a trampoline");
-  set_destination(trampoline_stub_addr);
+  if (Assembler::reachable_from_branch_at(addr_call, dest)) {
+    set_destination(dest);
+  } else {
+    assert (trampoline_stub_addr != NULL, "we need a trampoline");
+    set_destination(trampoline_stub_addr);
+  }
 
   ICache::invalidate_range(addr_call, instruction_size);
 }


### PR DESCRIPTION
Hi team,

Java calls will jump to the trampoline stub even if the target address is directly reachable by using a simple `jal` before this patch. After adding back the logic from the AArch64 platform, we find a nearly 4% performance enhancement on SPECjbb2005/15. Tested tests under hotspot/ and jdk/. [Original Patch](https://github.com/riscv-collab/riscv-openjdk/pull/8)

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277392](https://bugs.openjdk.java.net/browse/JDK-8277392): riscv: Port missing trampoline logic from AArch64 platform


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/8.diff">https://git.openjdk.java.net/riscv-port/pull/8.diff</a>

</details>
