### PR TITLE
8277036: riscv: Get CPU features from the auxiliary vector on Linux

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.cpp
@@ -364,4 +364,3 @@ Address::Address(address target, relocInfo::relocType rtype) : _base(noreg), _of
       ShouldNotReachHere();
   }
 }
-

--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -292,4 +292,3 @@ void BarrierSetAssembler::c2i_entry_barrier(MacroAssembler* masm) {
   __ far_jump(RuntimeAddress(SharedRuntime::get_handle_wrong_method_stub()));
   __ bind(method_live);
 }
-

--- a/src/hotspot/cpu/riscv/gc/shenandoah/shenandoah_riscv64.ad
+++ b/src/hotspot/cpu/riscv/gc/shenandoah/shenandoah_riscv64.ad
@@ -43,7 +43,7 @@ instruct compareAndSwapP_shenandoah(iRegINoSp res, indirect mem, iRegP oldval, i
     __ mv(tmp, $oldval$$Register); // Must not clobber oldval.
     ShenandoahBarrierSet::assembler()->cmpxchg_oop(&_masm, $mem$$Register, tmp, $newval$$Register,
                                                    Assembler::relaxed /* acquire */, Assembler::rl /* release */,
-                                                   false /* is_cae */, $res$$Register);   
+                                                   false /* is_cae */, $res$$Register);
   %}
 
   ins_pipe(pipe_slow);
@@ -194,7 +194,7 @@ instruct compareAndExchangeNAcq_shenandoah(iRegNNoSp res, indirect mem, iRegN ol
                                                    true /* is_cae */, $res$$Register);
   %}
 
-  ins_pipe(pipe_slow); 
+  ins_pipe(pipe_slow);
 %}
 
 instruct compareAndExchangePAcq_shenandoah(iRegPNoSp res, indirect mem, iRegP oldval, iRegP newval, iRegPNoSp tmp, rFlagsReg cr) %{

--- a/src/hotspot/cpu/riscv/gc/z/z_riscv64.ad
+++ b/src/hotspot/cpu/riscv/gc/z/z_riscv64.ad
@@ -137,7 +137,7 @@ instruct zCompareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP ne
                  Assembler::aq /* acquire */, Assembler::rl /* release */, $res$$Register,
                  true /* result_as_bool */);
       __ bind(good);
-    }  
+    }
   %}
 
   ins_pipe(pipe_slow);

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -415,4 +415,3 @@ void NativeMembar::set_kind(uint32_t order_kind) {
   address membar = addr_at(0);
   *(unsigned int*) membar = insn;
 }
-

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -9693,7 +9693,7 @@ instruct cmovI_cmpU(iRegINoSp dst, iRegI src, iRegI op1, iRegI op2, cmpOpU cop) 
              "bneg$cop $op1, $op2, skip\t#@cmovI_cmpU\n\t"
              "mv $dst, $src\n\t"
              "skip:"
-         %}    
+         %}
 
   ins_encode %{
     __ enc_cmove($cop$$cmpcode | C2_MacroAssembler::unsigned_branch_mask,

--- a/src/hotspot/cpu/riscv/riscv_vext.ad
+++ b/src/hotspot/cpu/riscv/riscv_vext.ad
@@ -445,7 +445,7 @@ instruct vminD(vReg dst, vReg src1, vReg src2) %{
   ins_cost(VEC_COST);
   format %{ "vminD $dst, $src1, $src2\t#@vminD" %}
   ins_encode %{
-    __ minmax_FD_v(as_VectorRegister($dst$$reg),   
+    __ minmax_FD_v(as_VectorRegister($dst$$reg),
                    as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg),
                    true /* is_double */, true /* is_min */);
   %}
@@ -1067,7 +1067,7 @@ instruct vreduce_maxD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
     __ reduce_minmax_FD_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          true /* is_double */, false /* is_min */); 
+                          true /* is_double */, false /* is_min */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1084,7 +1084,7 @@ instruct vreduce_minF(fRegF dst, fRegF src1, vReg src2, vReg tmp1, vReg tmp2) %{
     __ reduce_minmax_FD_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          false /* is_double */, true /* is_min */); 
+                          false /* is_double */, true /* is_min */);
   %}
   ins_pipe(pipe_slow);
 %}
@@ -1099,7 +1099,7 @@ instruct vreduce_minD(fRegD dst, fRegD src1, vReg src2, vReg tmp1, vReg tmp2) %{
     __ reduce_minmax_FD_v($dst$$FloatRegister,
                           $src1$$FloatRegister, as_VectorRegister($src2$$reg),
                           as_VectorRegister($tmp1$$reg), as_VectorRegister($tmp2$$reg),
-                          true /* is_double */, true /* is_min */); 
+                          true /* is_double */, true /* is_min */);
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -42,13 +42,13 @@ public:
 
   enum Feature_Flag {
 #define CPU_FEATURE_FLAGS(decl)               \
-    decl(A,            "A",            0)     \
-    decl(B,            "B",            1)     \
-    decl(C,            "C",            2)     \
-    decl(D,            "D",            3)     \
-    decl(F,            "F",            5)     \
     decl(I,            "I",            8)     \
     decl(M,            "M",           12)     \
+    decl(A,            "A",            0)     \
+    decl(F,            "F",            5)     \
+    decl(D,            "D",            3)     \
+    decl(B,            "B",            1)     \
+    decl(C,            "C",            2)     \
     decl(V,            "V",           21)
 
 #define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1 << bit),

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -39,21 +39,28 @@ public:
 
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
-  static bool is_checkvext_fault(address pc) {
-    return pc != NULL && pc == _checkvext_fault_pc;
-  }
 
-  static address continuation_for_checkvext_fault(address pc) {
-    assert(_checkvext_continuation_pc != NULL, "not initialized");
-    return _checkvext_continuation_pc;
-  }
+  enum Feature_Flag {
+#define CPU_FEATURE_FLAGS(decl)               \
+    decl(A,            "A",            0)     \
+    decl(B,            "B",            1)     \
+    decl(C,            "C",            2)     \
+    decl(D,            "D",            3)     \
+    decl(F,            "F",            5)     \
+    decl(I,            "I",            8)     \
+    decl(M,            "M",           12)     \
+    decl(V,            "V",           21)
 
-  static address _checkvext_fault_pc;
-  static address _checkvext_continuation_pc;
+#define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1 << bit),
+    CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)
+#undef DECLARE_CPU_FEATURE_FLAG
+  };
 
 protected:
-  static int _initial_vector_length;
+  static uint32_t _initial_vector_length;
   static void get_processor_features();
+  static void get_cpu_info();
+  static uint32_t get_current_vector_length();
 
 #ifdef COMPILER2
 private:

--- a/src/hotspot/os_cpu/linux_riscv/assembler_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/assembler_linux_riscv.cpp
@@ -24,5 +24,3 @@
  */
 
 // nothing required here
-
-

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -202,12 +202,6 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       }
     }
 
-    if (sig == SIGILL && VM_Version::is_checkvext_fault(pc)) {
-      os::Posix::ucontext_set_pc(uc, VM_Version::continuation_for_checkvext_fault(pc));
-      return true;
-    }
-
-
     if (thread->thread_state() == _thread_in_Java) {
       // Java thread running in Java code => find exception handler if any
       // a fault inside compiled code, the interpreter, or a stub

--- a/src/hotspot/os_cpu/linux_riscv/thread_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/thread_linux_riscv.cpp
@@ -90,4 +90,3 @@ bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava)
 }
 
 void JavaThread::cache_global_variables() { }
-

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2006, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#include "precompiled.hpp"
+#include "asm/register.hpp"
+#include "runtime/os.hpp"
+#include "runtime/os.inline.hpp"
+#include "runtime/vm_version.hpp"
+
+#include <asm/hwcap.h>
+#include <sys/auxv.h>
+
+#ifndef HWCAP_ISA_I
+#define HWCAP_ISA_I  (1 << ('I' - 'A'))
+#endif
+
+#ifndef HWCAP_ISA_M
+#define HWCAP_ISA_M  (1 << ('M' - 'A'))
+#endif
+
+#ifndef HWCAP_ISA_A
+#define HWCAP_ISA_A  (1 << ('A' - 'A'))
+#endif
+
+#ifndef HWCAP_ISA_F
+#define HWCAP_ISA_F  (1 << ('F' - 'A'))
+#endif
+
+#ifndef HWCAP_ISA_D
+#define HWCAP_ISA_D  (1 << ('D' - 'A'))
+#endif
+
+#ifndef HWCAP_ISA_C
+#define HWCAP_ISA_C  (1 << ('C' - 'A'))
+#endif
+
+#ifndef HWCAP_ISA_V
+#define HWCAP_ISA_V  (1 << ('V' - 'A'))
+#endif
+
+#ifndef HWCAP_ISA_B
+#define HWCAP_ISA_B  (1 << ('B' - 'A'))
+#endif
+
+#define read_csr(csr)                                           \
+({                                                              \
+        register unsigned long __v;                             \
+        __asm__ __volatile__ ("csrr %0, %1"                     \
+                              : "=r" (__v)                      \
+                              : "i" (csr)                       \
+                              : "memory");                      \
+        __v;                                                    \
+})
+
+uint32_t VM_Version::get_current_vector_length() {
+  assert(_features & CPU_V, "should not call this");
+  return (uint32_t)read_csr(CSR_VLENB);
+}
+
+void VM_Version::get_cpu_info() {
+
+  uint64_t auxv = getauxval(AT_HWCAP);
+
+  static_assert(CPU_A == HWCAP_ISA_A, "Flag CPU_A must follow Linux HWCAP");
+  static_assert(CPU_B == HWCAP_ISA_B, "Flag CPU_B must follow Linux HWCAP");
+  static_assert(CPU_C == HWCAP_ISA_C, "Flag CPU_C must follow Linux HWCAP");
+  static_assert(CPU_D == HWCAP_ISA_D, "Flag CPU_D must follow Linux HWCAP");
+  static_assert(CPU_F == HWCAP_ISA_F, "Flag CPU_F must follow Linux HWCAP");
+  static_assert(CPU_I == HWCAP_ISA_I, "Flag CPU_I must follow Linux HWCAP");
+  static_assert(CPU_M == HWCAP_ISA_M, "Flag CPU_M must follow Linux HWCAP");
+  static_assert(CPU_V == HWCAP_ISA_V, "Flag CPU_V must follow Linux HWCAP");
+  _features = auxv & (
+      HWCAP_ISA_A |
+      HWCAP_ISA_D |
+      HWCAP_ISA_F |
+      HWCAP_ISA_I |
+      HWCAP_ISA_M |
+      HWCAP_ISA_V);
+}

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -52,16 +52,16 @@
 #define HWCAP_ISA_D  (1 << ('D' - 'A'))
 #endif
 
+#ifndef HWCAP_ISA_B
+#define HWCAP_ISA_B  (1 << ('B' - 'A'))
+#endif
+
 #ifndef HWCAP_ISA_C
 #define HWCAP_ISA_C  (1 << ('C' - 'A'))
 #endif
 
 #ifndef HWCAP_ISA_V
 #define HWCAP_ISA_V  (1 << ('V' - 'A'))
-#endif
-
-#ifndef HWCAP_ISA_B
-#define HWCAP_ISA_B  (1 << ('B' - 'A'))
 #endif
 
 #define read_csr(csr)                                           \
@@ -83,21 +83,21 @@ void VM_Version::get_cpu_info() {
 
   uint64_t auxv = getauxval(AT_HWCAP);
 
-  static_assert(CPU_A == HWCAP_ISA_A, "Flag CPU_A must follow Linux HWCAP");
-  static_assert(CPU_B == HWCAP_ISA_B, "Flag CPU_B must follow Linux HWCAP");
-  static_assert(CPU_C == HWCAP_ISA_C, "Flag CPU_C must follow Linux HWCAP");
-  static_assert(CPU_D == HWCAP_ISA_D, "Flag CPU_D must follow Linux HWCAP");
-  static_assert(CPU_F == HWCAP_ISA_F, "Flag CPU_F must follow Linux HWCAP");
   static_assert(CPU_I == HWCAP_ISA_I, "Flag CPU_I must follow Linux HWCAP");
   static_assert(CPU_M == HWCAP_ISA_M, "Flag CPU_M must follow Linux HWCAP");
+  static_assert(CPU_A == HWCAP_ISA_A, "Flag CPU_A must follow Linux HWCAP");
+  static_assert(CPU_F == HWCAP_ISA_F, "Flag CPU_F must follow Linux HWCAP");
+  static_assert(CPU_D == HWCAP_ISA_D, "Flag CPU_D must follow Linux HWCAP");
+  static_assert(CPU_B == HWCAP_ISA_B, "Flag CPU_B must follow Linux HWCAP");
+  static_assert(CPU_C == HWCAP_ISA_C, "Flag CPU_C must follow Linux HWCAP");
   static_assert(CPU_V == HWCAP_ISA_V, "Flag CPU_V must follow Linux HWCAP");
   _features = auxv & (
-      HWCAP_ISA_A |
-      HWCAP_ISA_B |
-      HWCAP_ISA_C |
-      HWCAP_ISA_D |
-      HWCAP_ISA_F |
       HWCAP_ISA_I |
       HWCAP_ISA_M |
+      HWCAP_ISA_A |
+      HWCAP_ISA_F |
+      HWCAP_ISA_D |
+      HWCAP_ISA_B |
+      HWCAP_ISA_C |
       HWCAP_ISA_V);
 }

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -93,6 +93,8 @@ void VM_Version::get_cpu_info() {
   static_assert(CPU_V == HWCAP_ISA_V, "Flag CPU_V must follow Linux HWCAP");
   _features = auxv & (
       HWCAP_ISA_A |
+      HWCAP_ISA_B |
+      HWCAP_ISA_C |
       HWCAP_ISA_D |
       HWCAP_ISA_F |
       HWCAP_ISA_I |


### PR DESCRIPTION
Due to the lack of native environment in our early development of riscv port, we detect riscv CPU ISA extensions through checking whether simulator (e.g. QEMU) supports execution of one of the instructions in the corresponding feature spec or not. Fortunately, there are several riscv hardwares available now, we can directly get this CPU info from the auxiliary vector on Linux. Note that the aarch64 port also did the same thing on Linux platform. This also fixes some whitespace issue reported by jcheck.

This has been tested on HiFive Unleashed board (rv64imafdc) and NeZha D1 board (rv64imafdcvu):
```
# HiFive Unmatched
$jdk/bin/java -XX:+UseVExt -XX:+PrintFlagsFinal -version |grep UseVExt
OpenJDK 64-Bit Server VM warning: RVV is not supported on this CPU
    bool UseVExt                                          = false                             {ARCH product} {command line}
openjdk version "18-internal" 2022-03-15
OpenJDK Runtime Environment (build 18-internal+0-adhoc..riscv-port)
OpenJDK 64-Bit Server VM (build 18-internal+0-adhoc..riscv-port, mixed mode)

$jdk/bin/java -XX:-UseVExt -XX:+PrintFlagsFinal -version |grep UseVExt
    bool UseVExt                                          = false                             {ARCH product} {command line}
openjdk version "18-internal" 2022-03-15
OpenJDK Runtime Environment (build 18-internal+0-adhoc..riscv-port)
OpenJDK 64-Bit Server VM (build 18-internal+0-adhoc..riscv-port, mixed mode)

$jdk/bin/java -XX:+PrintFlagsFinal -version |grep UseVExt
    bool UseVExt                                          = false                             {ARCH product} {command line}
openjdk version "18-internal" 2022-03-15
OpenJDK Runtime Environment (build 18-internal+0-adhoc..riscv-port)
OpenJDK 64-Bit Server VM (build 18-internal+0-adhoc..riscv-port, mixed mode)

# NeZha D1 
$jdk/bin/java -XX:+UseVExt -XX:+PrintFlagsFinal -version |grep UseVExt
    bool UseVExt                                          = true                             {ARCH product} {command line}
openjdk version "18-internal" 2022-03-15
OpenJDK Runtime Environment (build 18-internal+0-adhoc..riscv-port)
OpenJDK 64-Bit Server VM (build 18-internal+0-adhoc..riscv-port, mixed mode)

$jdk/bin/java -XX:-UseVExt -XX:+PrintFlagsFinal -version |grep UseVExt
    bool UseVExt                                          = false                             {ARCH product} {command line}
openjdk version "18-internal" 2022-03-15
OpenJDK Runtime Environment (build 18-internal+0-adhoc..riscv-port)
OpenJDK 64-Bit Server VM (build 18-internal+0-adhoc..riscv-port, mixed mode)

$jdk/bin/java -XX:+PrintFlagsFinal -version |grep UseVExt
    bool UseVExt                                          = false                             {ARCH product} {command line}
openjdk version "18-internal" 2022-03-15
OpenJDK Runtime Environment (build 18-internal+0-adhoc..riscv-port)
OpenJDK 64-Bit Server VM (build 18-internal+0-adhoc..riscv-port, mixed mode)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277036](https://bugs.openjdk.java.net/browse/JDK-8277036): riscv: Get CPU features from the auxiliary vector on Linux


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Feilong Jiang `<jiangfeilong@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/10.diff">https://git.openjdk.java.net/riscv-port/pull/10.diff</a>

</details>
