### PR TITLE
8277440: riscv: Move UseVExt from product to experimental

### DIFF
--- a/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
+++ b/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
@@ -134,10 +134,9 @@ void AbstractInterpreter::layout_activation(Method* method,
 #endif
 
   interpreter_frame->interpreter_frame_set_method(method);
-  // NOTE the difference in using sender_sp and
-  // interpreter_frame_sender_sp interpreter_frame_sender_sp is
-  // the original sp of the caller (the unextended_sp) and
-  // sender_sp is fp+8/16 (32bit/64bit)
+  // NOTE the difference in using sender_sp and interpreter_frame_sender_sp
+  // interpreter_frame_sender_sp is the original sp of the caller (the unextended_sp)
+  // and sender_sp is fp
   intptr_t* locals = NULL;
   if (caller->is_interpreted_frame()) {
     locals = caller->interpreter_frame_last_sp() + caller_actual_parameters - 1;

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1301,52 +1301,6 @@ enum VectorMask {
   unmasked = 0b1
 };
 
-// Vector AMO operations
-#define INSN(NAME, op, funct3, funct5)                                   \
-  void NAME(VectorRegister vSrc, Register rBase, VectorRegister vOffset, \
-            bool src_as_dst, VectorMask vm = unmasked) {                 \
-    unsigned insn = 0;                                                   \
-    patch((address)&insn, 6, 0, op);                                     \
-    patch((address)&insn, 14, 12, funct3);                               \
-    patch((address)&insn, 25, vm);                                       \
-    patch((address)&insn, 26, (uint32_t)src_as_dst);                     \
-    patch((address)&insn, 31, 27, funct5);                               \
-    patch_reg((address)&insn, 7, vSrc);                                  \
-    patch_reg((address)&insn, 15, rBase);                                \
-    patch_reg((address)&insn, 20, vOffset);                              \
-    emit(insn);                                                          \
-  }
-
-  INSN(vamoswapei8_v,  0b0101111, 0b000, 0b00001);
-  INSN(vamoswapei16_v, 0b0101111, 0b101, 0b00001);
-  INSN(vamoswapei32_v, 0b0101111, 0b110, 0b00001);
-  INSN(vamoaddei8_v,   0b0101111, 0b000, 0b00000);
-  INSN(vamoaddei16_v,  0b0101111, 0b101, 0b00000);
-  INSN(vamoaddei32_v,  0b0101111, 0b110, 0b00000);
-  INSN(vamoxorei8_v,   0b0101111, 0b000, 0b00100);
-  INSN(vamoxorei16_v,  0b0101111, 0b101, 0b00100);
-  INSN(vamoxorei32_v,  0b0101111, 0b110, 0b00100);
-  INSN(vamoandei8_v,   0b0101111, 0b000, 0b01100);
-  INSN(vamoandei16_v,  0b0101111, 0b101, 0b01100);
-  INSN(vamoandei32_v,  0b0101111, 0b110, 0b01100);
-  INSN(vamoorei8_v,    0b0101111, 0b000, 0b01000);
-  INSN(vamoorei16_v,   0b0101111, 0b101, 0b01000);
-  INSN(vamoorei32_v,   0b0101111, 0b110, 0b01000);
-  INSN(vamominei8_v,   0b0101111, 0b000, 0b10000);
-  INSN(vamominei16_v,  0b0101111, 0b101, 0b10000);
-  INSN(vamominei32_v,  0b0101111, 0b110, 0b10000);
-  INSN(vamomaxei8_v,   0b0101111, 0b000, 0b10100);
-  INSN(vamomaxei16_v,  0b0101111, 0b101, 0b10100);
-  INSN(vamomaxei32_v,  0b0101111, 0b110, 0b10100);
-  INSN(vamominuei8_v,  0b0101111, 0b000, 0b11000);
-  INSN(vamominuei16_v, 0b0101111, 0b101, 0b11000);
-  INSN(vamominuei32_v, 0b0101111, 0b110, 0b11000);
-  INSN(vamomaxuei8_v,  0b0101111, 0b000, 0b11100);
-  INSN(vamomaxuei16_v, 0b0101111, 0b101, 0b11100);
-  INSN(vamomaxuei32_v, 0b0101111, 0b110, 0b11100);
-
-#undef INSN
-
 #define patch_VArith(op, Reg, funct3, Reg_or_Imm5, Vs2, vm, funct6)            \
     unsigned insn = 0;                                                         \
     patch((address)&insn, 6, 0, op);                                           \
@@ -1396,25 +1350,6 @@ enum VectorMask {
   INSN(vfcvt_rtz_xu_f_v, 0b1010111, 0b001, 0b00110, 0b010010);
   INSN(vfcvt_rtz_x_f_v,  0b1010111, 0b001, 0b00111, 0b010010);
 
-  // Vector Widening Floating-Point/Integer Type-Convert Instructions
-  INSN(vfwcvt_xu_f_v, 0b1010111, 0b001, 0b01000, 0b010010);
-  INSN(vfwcvt_x_f_v,  0b1010111, 0b001, 0b01001, 0b010010);
-  INSN(vfwcvt_f_xu_v, 0b1010111, 0b001, 0b01010, 0b010010);
-  INSN(vfwcvt_f_x_v,  0b1010111, 0b001, 0b01011, 0b010010);
-  INSN(vfwcvt_f_f_v,  0b1010111, 0b001, 0b01100, 0b010010);
-  INSN(vfwcvt_rtz_xu_f_v, 0b1010111, 0b001, 0b01110, 0b010010);
-  INSN(vfwcvt_rtz_x_f_v,  0b1010111, 0b001, 0b01111, 0b010010);
-
-  // Vector Narrowing Floating-Point/Integer Type-Convert Instructions
-  INSN(vfncvt_xu_f_w, 0b1010111, 0b001, 0b10000, 0b010010);
-  INSN(vfncvt_x_f_w,  0b1010111, 0b001, 0b10001, 0b010010);
-  INSN(vfncvt_f_xu_w, 0b1010111, 0b001, 0b10010, 0b010010);
-  INSN(vfncvt_f_x_w,  0b1010111, 0b001, 0b10011, 0b010010);
-  INSN(vfncvt_f_f_w,  0b1010111, 0b001, 0b10100, 0b010010);
-  INSN(vfncvt_rod_f_f_w,  0b1010111, 0b001, 0b10101, 0b010010);
-  INSN(vfncvt_rtz_xu_f_w, 0b1010111, 0b001, 0b10110, 0b010010);
-  INSN(vfncvt_rtz_x_f_w,  0b1010111, 0b001, 0b10111, 0b010010);
-
   // Vector Floating-Point Instruction
   INSN(vfsqrt_v,  0b1010111, 0b001, 0b00000, 0b010011);
   INSN(vfclass_v, 0b1010111, 0b001, 0b10000, 0b010011);
@@ -1462,25 +1397,6 @@ enum VectorMask {
     patch_VArith(op, Vd, funct3, (uint32_t)(imm & 0x1f), Vs2, vm, funct6);                         \
   }
 
-  // Vector Register Gather Instruction
-  INSN(vrgather_vi,   0b1010111, 0b011, 0b001100);
-
-  // Vector Slide Instructions
-  INSN(vslidedown_vi, 0b1010111, 0b011, 0b001111);
-  INSN(vslideup_vi,   0b1010111, 0b011, 0b001110);
-
-  // Vector Narrowing Fixed-Point Clip Instructions
-  INSN(vnclip_wi,  0b1010111, 0b011, 0b101111);
-  INSN(vnclipu_wi, 0b1010111, 0b011, 0b101110);
-
-  // Vector Single-Width Scaling Shift Instructions
-  INSN(vssra_vi,   0b1010111, 0b011, 0b101011);
-  INSN(vssrl_vi,   0b1010111, 0b011, 0b101010);
-
-  // Vector Narrowing Integer Right Shift Instructions
-  INSN(vnsra_wi,   0b1010111, 0b011, 0b101101);
-  INSN(vnsrl_wi,   0b1010111, 0b011, 0b101100);
-
   // Vector Single-Width Bit Shift Instructions
   INSN(vsra_vi,    0b1010111, 0b011, 0b101001);
   INSN(vsrl_vi,    0b1010111, 0b011, 0b101000);
@@ -1493,12 +1409,6 @@ enum VectorMask {
     patch_VArith(op, Vd, funct3, Vs1->encoding_nocheck(), Vs2, vm, funct6);                        \
   }
 
-  // Vector Widening Floating-Point Fused Multiply-Add Instructions
-  INSN(vfwnmsac_vv, 0b1010111, 0b001, 0b111111);
-  INSN(vfwmsac_vv,  0b1010111, 0b001, 0b111110);
-  INSN(vfwnmacc_vv, 0b1010111, 0b001, 0b111101);
-  INSN(vfwmacc_vv,  0b1010111, 0b001, 0b111100);
-
   // Vector Single-Width Floating-Point Fused Multiply-Add Instructions
   INSN(vfnmsub_vv, 0b1010111, 0b001, 0b101011);
   INSN(vfmsub_vv,  0b1010111, 0b001, 0b101010);
@@ -1508,11 +1418,6 @@ enum VectorMask {
   INSN(vfmsac_vv,  0b1010111, 0b001, 0b101110);
   INSN(vfmacc_vv,  0b1010111, 0b001, 0b101100);
   INSN(vfnmacc_vv, 0b1010111, 0b001, 0b101101);
-
-  // Vector Widening Integer Multiply-Add Instructions
-  INSN(vwmaccsu_vv, 0b1010111, 0b010, 0b111111);
-  INSN(vwmacc_vv,   0b1010111, 0b010, 0b111101);
-  INSN(vwmaccu_vv,  0b1010111, 0b010, 0b111100);
 
   // Vector Single-Width Integer Multiply-Add Instructions
   INSN(vnmsub_vv, 0b1010111, 0b010, 0b101011);
@@ -1526,12 +1431,6 @@ enum VectorMask {
   void NAME(VectorRegister Vd, Register Rs1, VectorRegister Vs2, VectorMask vm = unmasked) {       \
     patch_VArith(op, Vd, funct3, Rs1->encoding_nocheck(), Vs2, vm, funct6);                        \
   }
-
-  // Vector Widening Integer Multiply-Add Instructions
-  INSN(vwmaccsu_vx, 0b1010111, 0b110, 0b111111);
-  INSN(vwmacc_vx,   0b1010111, 0b110, 0b111101);
-  INSN(vwmaccu_vx,  0b1010111, 0b110, 0b111100);
-  INSN(vwmaccus_vx, 0b1010111, 0b110, 0b111110);
 
   // Vector Single-Width Integer Multiply-Add Instructions
   INSN(vnmsub_vx, 0b1010111, 0b110, 0b101011);
@@ -1547,12 +1446,6 @@ enum VectorMask {
   void NAME(VectorRegister Vd, FloatRegister Rs1, VectorRegister Vs2, VectorMask vm = unmasked) {  \
     patch_VArith(op, Vd, funct3, Rs1->encoding_nocheck(), Vs2, vm, funct6);                        \
   }
-
-  // Vector Widening Floating-Point Fused Multiply-Add Instructions
-  INSN(vfwnmsac_vf, 0b1010111, 0b101, 0b111111);
-  INSN(vfwmsac_vf,  0b1010111, 0b101, 0b111110);
-  INSN(vfwnmacc_vf, 0b1010111, 0b101, 0b111101);
-  INSN(vfwmacc_vf,  0b1010111, 0b101, 0b111100);
 
   // Vector Single-Width Floating-Point Fused Multiply-Add Instructions
   INSN(vfnmsub_vf, 0b1010111, 0b101, 0b101011);
@@ -1571,14 +1464,6 @@ enum VectorMask {
     patch_VArith(op, Vd, funct3, Vs1->encoding_nocheck(), Vs2, vm, funct6);                        \
   }
 
-  // Vector Register Gather Instruction
-  INSN(vrgather_vv,     0b1010111, 0b000, 0b001100);
-  INSN(vrgatherei16_vv, 0b1010111, 0b000, 0b001110);
-
-  // Vector Widening Floating-Point Reduction Instructions
-  INSN(vfwredsum_vs,  0b1010111, 0b001, 0b110001);
-  INSN(vfwredosum_vs, 0b1010111, 0b001, 0b110011);
-
   // Vector Single-Width Floating-Point Reduction Instructions
   INSN(vfredsum_vs,   0b1010111, 0b001, 0b000001);
   INSN(vfredosum_vs,  0b1010111, 0b001, 0b000011);
@@ -1595,10 +1480,6 @@ enum VectorMask {
   INSN(vredmaxu_vs,   0b1010111, 0b010, 0b000110);
   INSN(vredmax_vs,    0b1010111, 0b010, 0b000111);
 
-  // Vector Widening Integer Reduction Instructions
-  INSN(vwredsumu_vs,  0b1010111, 0b000, 0b110000);
-  INSN(vwredsum_vs,   0b1010111, 0b000, 0b110001);
-
   // Vector Floating-Point Compare Instructions
   INSN(vmfle_vv, 0b1010111, 0b001, 0b011001);
   INSN(vmflt_vv, 0b1010111, 0b001, 0b011011);
@@ -1614,50 +1495,16 @@ enum VectorMask {
   INSN(vfmax_vv,   0b1010111, 0b001, 0b000110);
   INSN(vfmin_vv,   0b1010111, 0b001, 0b000100);
 
-  // Vector Widening Floating-Point Multiply
-  INSN(vfwmul_vv,  0b1010111, 0b001, 0b111000);
-
   // Vector Single-Width Floating-Point Multiply/Divide Instructions
   INSN(vfdiv_vv,   0b1010111, 0b001, 0b100000);
   INSN(vfmul_vv,   0b1010111, 0b001, 0b100100);
-
-  // Vector Widening Floating-Point Add/Subtract Instructions
-  INSN(vfwsub_wv, 0b1010111, 0b001, 0b110110);
-  INSN(vfwsub_vv, 0b1010111, 0b001, 0b110010);
-  INSN(vfwadd_wv, 0b1010111, 0b001, 0b110100);
-  INSN(vfwadd_vv, 0b1010111, 0b001, 0b110000);
 
   // Vector Single-Width Floating-Point Add/Subtract Instructions
   INSN(vfsub_vv, 0b1010111, 0b001, 0b000010);
   INSN(vfadd_vv, 0b1010111, 0b001, 0b000000);
 
-  // Vector Narrowing Fixed-Point Clip Instructions
-  INSN(vnclip_wv,  0b1010111, 0b000, 0b101111);
-  INSN(vnclipu_wv, 0b1010111, 0b000, 0b101110);
-
-  // Vector Single-Width Scaling Shift Instructions
-  INSN(vssra_vv, 0b1010111, 0b000, 0b101011);
-  INSN(vssrl_vv, 0b1010111, 0b000, 0b101010);
-
   // Vector Single-Width Fractional Multiply with Rounding and Saturation
   INSN(vsmul_vv, 0b1010111, 0b000, 0b100111);
-
-  // Vector Single-Width Averaging Add and Subtract
-  INSN(vasubu_vv, 0b1010111, 0b010, 0b001010);
-  INSN(vasub_vv,  0b1010111, 0b010, 0b001011);
-  INSN(vaaddu_vv, 0b1010111, 0b010, 0b001000);
-  INSN(vaadd_vv,  0b1010111, 0b010, 0b001001);
-
-  // Vector Single-Width Saturating Add and Subtract
-  INSN(vssub_vv,  0b1010111, 0b000, 0b100011);
-  INSN(vssubu_vv, 0b1010111, 0b000, 0b100010);
-  INSN(vsadd_vv,  0b1010111, 0b000, 0b100001);
-  INSN(vsaddu_vv, 0b1010111, 0b000, 0b100000);
-
-  // Vector Widening Integer Multiply Instructions
-  INSN(vwmul_vv,   0b1010111, 0b010, 0b111011);
-  INSN(vwmulsu_vv, 0b1010111, 0b010, 0b111010);
-  INSN(vwmulu_vv,  0b1010111, 0b010, 0b111000);
 
   // Vector Integer Divide Instructions
   INSN(vrem_vv,  0b1010111, 0b010, 0b100011);
@@ -1685,10 +1532,6 @@ enum VectorMask {
   INSN(vmsne_vv,  0b1010111, 0b000, 0b011001);
   INSN(vmseq_vv,  0b1010111, 0b000, 0b011000);
 
-  // Vector Narrowing Integer Right Shift Instructions
-  INSN(vnsra_wv, 0b1010111, 0b000, 0b101101);
-  INSN(vnsrl_wv, 0b1010111, 0b000, 0b101100);
-
   // Vector Single-Width Bit Shift Instructions
   INSN(vsra_vv, 0b1010111, 0b000, 0b101001);
   INSN(vsrl_vv, 0b1010111, 0b000, 0b101000);
@@ -1698,16 +1541,6 @@ enum VectorMask {
   INSN(vxor_vv, 0b1010111, 0b000, 0b001011);
   INSN(vor_vv,  0b1010111, 0b000, 0b001010);
   INSN(vand_vv, 0b1010111, 0b000, 0b001001);
-
-  // Vector Widening Integer Add/Subtract
-  INSN(vwsub_wv,  0b1010111, 0b010, 0b110111);
-  INSN(vwsubu_wv, 0b1010111, 0b010, 0b110110);
-  INSN(vwadd_wv,  0b1010111, 0b010, 0b110101);
-  INSN(vwaddu_wv, 0b1010111, 0b010, 0b110100);
-  INSN(vwsub_vv,  0b1010111, 0b010, 0b110011);
-  INSN(vwsubu_vv, 0b1010111, 0b010, 0b110010);
-  INSN(vwadd_vv,  0b1010111, 0b010, 0b110001);
-  INSN(vwaddu_vv, 0b1010111, 0b010, 0b110000);
 
   // Vector Single-Width Integer Add and Subtract
   INSN(vsub_vv, 0b1010111, 0b000, 0b000010);
@@ -1720,43 +1553,6 @@ enum VectorMask {
   void NAME(VectorRegister Vd, VectorRegister Vs2, Register Rs1, VectorMask vm = unmasked) {       \
     patch_VArith(op, Vd, funct3, Rs1->encoding_nocheck(), Vs2, vm, funct6);                        \
   }
-
-  // Vector Register Gather Instruction
-  INSN(vrgather_vx, 0b1010111, 0b100, 0b001100);
-
-  // Vector Slide Instructions
-  INSN(vslide1down_vx, 0b1010111, 0b110, 0b001111);
-  INSN(vslidedown_vx,  0b1010111, 0b100, 0b001111);
-  INSN(vslide1up_vx,   0b1010111, 0b110, 0b001110);
-  INSN(vslideup_vx,    0b1010111, 0b100, 0b001110);
-
-  // Vector Narrowing Fixed-Point Clip Instructions
-  INSN(vnclip_wx,  0b1010111, 0b100, 0b101111);
-  INSN(vnclipu_wx, 0b1010111, 0b100, 0b101110);
-
-  // Vector Single-Width Scaling Shift Instructions
-  INSN(vssra_vx, 0b1010111, 0b100, 0b101011);
-  INSN(vssrl_vx, 0b1010111, 0b100, 0b101010);
-
-  // Vector Single-Width Fractional Multiply with Rounding and Saturation
-  INSN(vsmul_vx, 0b1010111, 0b100, 0b100111);
-
-  // Vector Single-Width Averaging Add and Subtract
-  INSN(vasubu_vx, 0b1010111, 0b110, 0b001010);
-  INSN(vasub_vx,  0b1010111, 0b110, 0b001011);
-  INSN(vaaddu_vx, 0b1010111, 0b110, 0b001000);
-  INSN(vaadd_vx,  0b1010111, 0b110, 0b001001);
-
-  // Vector Single-Width Saturating Add and Subtract
-  INSN(vssub_vx,  0b1010111, 0b100, 0b100011);
-  INSN(vssubu_vx, 0b1010111, 0b100, 0b100010);
-  INSN(vsadd_vx,  0b1010111, 0b100, 0b100001);
-  INSN(vsaddu_vx, 0b1010111, 0b100, 0b100000);
-
-  // Vector Widening Integer Multiply Instructions
-  INSN(vwmul_vx,   0b1010111, 0b110, 0b111011);
-  INSN(vwmulsu_vx, 0b1010111, 0b110, 0b111010);
-  INSN(vwmulu_vx,  0b1010111, 0b110, 0b111000);
 
   // Vector Integer Divide Instructions
   INSN(vrem_vx,  0b1010111, 0b110, 0b100011);
@@ -1800,17 +1596,6 @@ enum VectorMask {
   INSN(vor_vx,  0b1010111, 0b100, 0b001010);
   INSN(vand_vx, 0b1010111, 0b100, 0b001001);
 
-  // Vector Widening Integer Add/Subtract
-  INSN(vwsub_wx,  0b1010111, 0b110, 0b110111);
-  INSN(vwsubu_wx, 0b1010111, 0b110, 0b110110);
-  INSN(vwadd_wx,  0b1010111, 0b110, 0b110101);
-  INSN(vwadd_wv,  0b1010111, 0b010, 0b110101);
-  INSN(vwaddu_wx, 0b1010111, 0b110, 0b110100);
-  INSN(vwsub_vx,  0b1010111, 0b110, 0b110011);
-  INSN(vwsubu_vx, 0b1010111, 0b110, 0b110010);
-  INSN(vwadd_vx,  0b1010111, 0b110, 0b110001);
-  INSN(vwaddu_vx, 0b1010111, 0b110, 0b110000);
-
   // Vector Single-Width Integer Add and Subtract
   INSN(vsub_vx, 0b1010111, 0b100, 0b000010);
   INSN(vadd_vx, 0b1010111, 0b100, 0b000000);
@@ -1830,10 +1615,6 @@ enum VectorMask {
   INSN(vmfne_vf, 0b1010111, 0b101, 0b011100);
   INSN(vmfeq_vf, 0b1010111, 0b101, 0b011000);
 
-  // Vector Slide1up/Slide1down Instruction
-  INSN(vfslide1down_vf, 0b1010111, 0b101, 0b001111);
-  INSN(vfslide1up_vf,   0b1010111, 0b101, 0b001110);
-
   // Vector Floating-Point Sign-Injection Instructions
   INSN(vfsgnjx_vf, 0b1010111, 0b101, 0b001010);
   INSN(vfsgnjn_vf, 0b1010111, 0b101, 0b001001);
@@ -1843,19 +1624,10 @@ enum VectorMask {
   INSN(vfmax_vf, 0b1010111, 0b101, 0b000110);
   INSN(vfmin_vf, 0b1010111, 0b101, 0b000100);
 
-  // Vector Widening Floating-Point Multiply
-  INSN(vfwmul_vf, 0b1010111, 0b101, 0b111000);
-
   // Vector Single-Width Floating-Point Multiply/Divide Instructions
   INSN(vfdiv_vf,  0b1010111, 0b101, 0b100000);
   INSN(vfmul_vf,  0b1010111, 0b101, 0b100100);
   INSN(vfrdiv_vf, 0b1010111, 0b101, 0b100001);
-
-  // Vector Widening Floating-Point Add/Subtract Instructions
-  INSN(vfwsub_wf, 0b1010111, 0b101, 0b110110);
-  INSN(vfwsub_vf, 0b1010111, 0b101, 0b110010);
-  INSN(vfwadd_wf, 0b1010111, 0b101, 0b110100);
-  INSN(vfwadd_vf, 0b1010111, 0b101, 0b110000);
 
   // Vector Single-Width Floating-Point Add/Subtract Instructions
   INSN(vfsub_vf,  0b1010111, 0b101, 0b000010);
@@ -1870,8 +1642,6 @@ enum VectorMask {
     patch_VArith(op, Vd, funct3, (uint32_t)imm & 0x1f, Vs2, vm, funct6);                           \
   }
 
-  INSN(vsadd_vi,  0b1010111, 0b011, 0b100001);
-  INSN(vsaddu_vi, 0b1010111, 0b011, 0b100000);
   INSN(vmsgt_vi,  0b1010111, 0b011, 0b011111);
   INSN(vmsgtu_vi, 0b1010111, 0b011, 0b011110);
   INSN(vmsle_vi,  0b1010111, 0b011, 0b011101);
@@ -1912,67 +1682,6 @@ enum VectorMask {
   INSN(vmandnot_mm, 0b1010111, 0b010, 0b1, 0b011000);
   INSN(vmnand_mm,   0b1010111, 0b010, 0b1, 0b011101);
   INSN(vmand_mm,    0b1010111, 0b010, 0b1, 0b011001);
-
-#undef INSN
-
-#define INSN(NAME, op, funct3, vm, funct6)                                                  \
-  void NAME(VectorRegister Vd, VectorRegister Vs2, int32_t imm, VectorRegister V0) {        \
-    guarantee(is_imm_in_range(imm, 5, 0), "imm is invalid");                                \
-    patch_VArith(op, Vd, funct3, (uint32_t)(imm & 0x1f), Vs2, vm, funct6);                  \
-  }
-
-  // Vector Integer Merge Instructions
-  INSN(vmerge_vim, 0b1010111, 0b011, 0b0, 0b010111);
-
-  // Vector Integer Add-with-Carry / Subtract-with-Borrow Instructions
-  INSN(vadc_vim,   0b1010111, 0b011, 0b0, 0b010000);
-  INSN(vmadc_vim,  0b1010111, 0b011, 0b0, 0b010001);
-
-#undef INSN
-
-#define INSN(NAME, op, funct3, vm, funct6)                                                  \
-  void NAME(VectorRegister Vd, VectorRegister Vs2, VectorRegister Vs1, VectorRegister V0) { \
-    patch_VArith(op, Vd, funct3, Vs1->encoding_nocheck(), Vs2, vm, funct6);                 \
-  }
-
-  // Vector Integer Merge Instructions
-  INSN(vmerge_vvm, 0b1010111, 0b000, 0b0, 0b010111);
-
-  // Vector Integer Add-with-Carry / Subtract-with-Borrow Instructions
-  INSN(vsbc_vvm, 0b1010111, 0b000, 0b0, 0b010010);
-  INSN(vadc_vvm, 0b1010111, 0b000, 0b0, 0b010000);
-
-  // Vector Integer Add-with-Carry / Subtract-with-Borrow Instructions
-  INSN(vmadc_vvm, 0b1010111, 0b000, 0b0, 0b010001);
-  INSN(vmsbc_vvm, 0b1010111, 0b000, 0b0, 0b010011);
-
-#undef INSN
-
-#define INSN(NAME, op, funct3, vm, funct6)                                                  \
-  void NAME(VectorRegister Vd, VectorRegister Vs2, FloatRegister Rs1, VectorRegister V0) {  \
-    patch_VArith(op, Vd, funct3, Rs1->encoding_nocheck(), Vs2, vm, funct6);                 \
-  }
-
-  // Vector Floating-Point Merge Instruction
-  INSN(vfmerge_vfm, 0b1010111, 0b101, 0b0, 0b010111);
-
-#undef INSN
-
-#define INSN(NAME, op, funct3, vm, funct6)                                                  \
-  void NAME(VectorRegister Vd, VectorRegister Vs2, Register Rs1, VectorRegister V0) {       \
-    patch_VArith(op, Vd, funct3, Rs1->encoding_nocheck(), Vs2, vm, funct6);                 \
-  }
-
-  // Vector Integer Merge Instructions
-  INSN(vmerge_vxm, 0b1010111, 0b100, 0b0, 0b010111);
-
-  // Vector Integer Add-with-Carry / Subtract-with-Borrow Instructions
-  INSN(vsbc_vxm, 0b1010111, 0b100, 0b0, 0b010010);
-  INSN(vadc_vxm, 0b1010111, 0b100, 0b0, 0b010000);
-
-  // Vector Integer Add-with-Carry / Subtract-with-Borrow Instructions
-  INSN(vmadc_vxm, 0b1010111, 0b100, 0b0, 0b010001);
-  INSN(vmsbc_vxm, 0b1010111, 0b100, 0b0, 0b010011);
 
 #undef INSN
 
@@ -2148,37 +1857,6 @@ enum Nf {
   INSN(vlse16_v, 0b0000111, 0b101, 0b10, 0b0);
   INSN(vlse32_v, 0b0000111, 0b110, 0b10, 0b0);
   INSN(vlse64_v, 0b0000111, 0b111, 0b10, 0b0);
-
-#undef INSN
-
-#define INSN(NAME, op, width, mop, mew)                                                                   \
-  void NAME(VectorRegister Vs3, Register Rs1, VectorRegister Vs2, VectorMask vm = unmasked, Nf nf = g1) { \
-    patch_VLdSt(op, Vs3, width, Rs1, Vs2->encoding_nocheck(), vm, mop, mew, nf);                          \
-  }
-
-  // Vector unordered-indexed store instructions
-  INSN(vsuxei8_v,  0b0100111, 0b000, 0b01, 0b0);
-  INSN(vsuxei16_v, 0b0100111, 0b101, 0b01, 0b0);
-  INSN(vsuxei32_v, 0b0100111, 0b110, 0b01, 0b0);
-  INSN(vsuxei64_v, 0b0100111, 0b111, 0b01, 0b0);
-
-  // Vector ordered indexed store instructions
-  INSN(vsoxei8_v,  0b0100111, 0b000, 0b11, 0b0);
-  INSN(vsoxei16_v, 0b0100111, 0b101, 0b11, 0b0);
-  INSN(vsoxei32_v, 0b0100111, 0b110, 0b11, 0b0);
-  INSN(vsoxei64_v, 0b0100111, 0b111, 0b11, 0b0);
-
-#undef INSN
-
-#define INSN(NAME, op, width, mop, mew)                                                                   \
-  void NAME(VectorRegister Vs3, Register Rs1, Register Rs2, VectorMask vm = unmasked, Nf nf = g1) {       \
-    patch_VLdSt(op, Vs3, width, Rs1, Rs2->encoding_nocheck(), vm, mop, mew, nf);                          \
-  }
-
-  INSN(vsse8_v,  0b0100111, 0b000, 0b10, 0b0);
-  INSN(vsse16_v, 0b0100111, 0b101, 0b10, 0b0);
-  INSN(vsse32_v, 0b0100111, 0b110, 0b10, 0b0);
-  INSN(vsse64_v, 0b0100111, 0b111, 0b10, 0b0);
 
 #undef INSN
 #undef patch_VLdSt

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.hpp
@@ -42,7 +42,7 @@ using MacroAssembler::null_check;
   void try_allocate(
     Register obj,                      // result: pointer to object after successful allocation
     Register var_size_in_bytes,        // object size in bytes if unknown at compile time; invalid otherwise
-    int      con_size_in_bytes,        // object size in bytes if   known at compile time
+    int      con_size_in_bytes,        // object size in bytes if known at compile time
     Register tmp1,                     // temp register
     Register tmp2,                     // temp register
     Label&   slow_case                 // continuation point if fast allocation fails

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -241,7 +241,7 @@ enum reg_save_layout {
 };
 
 // Save off registers which might be killed by calls into the runtime.
-// Tries to smart of about FP registers.  In particular we separate
+// Tries to smart of about FPU registers.  In particular we separate
 // saving and describing the FPU registers for deoptimization since we
 // have to save the FPU registers twice if we describe them.  The
 // deopt blob is the only thing which needs to describe FPU registers.
@@ -259,7 +259,7 @@ static OopMap* generate_oop_map(StubAssembler* sasm, bool save_fpu_registers) {
   assert_cond(oop_map != NULL);
 
   // cpu_regs, caller save registers only, see FrameMap::initialize
-  // in c1_FrameMap_riscv64.cpp for detail.
+  // in c1_FrameMap_riscv.cpp for detail.
   const static Register caller_save_cpu_regs[FrameMap::max_nof_caller_save_cpu_regs] = {x7, x10, x11, x12,
                                                                                         x13, x14, x15, x16, x17,
                                                                                         x28,  x29, x30, x31};

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -88,7 +88,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
   product(bool, UseConservativeFence, true,                                      \
           "Extend i for r and o for w in the pred/succ flags of fence;"          \
           "Extend fence.i to fence.i + fence.")                                  \
-  product(bool, UseRVV, false, "Use RVV instructions")                           \
+  product(bool, UseRVV, false, EXPERIMENTAL, "Use RVV instructions")             \
   product(bool, AvoidUnalignedAccesses, true,                                    \
           "Avoid generating unaligned memory accesses")                          \
 

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -72,23 +72,24 @@ define_pd_global(intx, InitArrayShortSize, BytesPerLong);
 
 define_pd_global(intx, InlineSmallCode,          1000);
 
-#define ARCH_FLAGS(develop,                                             \
-                   product,                                             \
-                   notproduct,                                          \
-                   range,                                               \
-                   constraint)                                          \
-                                                                        \
-  product(bool, NearCpool, true,                                        \
-         "constant pool is close to instructions")                      \
-  product(intx, BlockZeroingLowLimit, 256,                              \
-          "Minimum size in bytes when block zeroing will be used")      \
-          range(1, max_jint)                                            \
-  product(bool, TraceTraps, false, "Trace all traps the signal handler")\
-  product(bool, UseConservativeFence, true,                             \
-          "Extend i for r and o for w in the pred/succ flags of fence;" \
-          "Extend fence.i to fence.i + fence.")                         \
-  product(bool, UseVExt, false, "Use RVV instructions")                 \
-  product(bool, AvoidUnalignedAccesses, true,                           \
-          "Avoid generating unaligned memory accesses")                 \
+#define ARCH_FLAGS(develop,                                                      \
+                   product,                                                      \
+                   notproduct,                                                   \
+                   range,                                                        \
+                   constraint)                                                   \
+                                                                                 \
+  product(bool, NearCpool, true,                                                 \
+         "constant pool is close to instructions")                               \
+  product(intx, BlockZeroingLowLimit, 256,                                       \
+          "Minimum size in bytes when block zeroing will be used")               \
+          range(1, max_jint)                                                     \
+  product(bool, TraceTraps, false, "Trace all traps the signal handler")         \
+  /* For now we're going to be safe and add the I/O bits to userspace fences. */ \
+  product(bool, UseConservativeFence, true,                                      \
+          "Extend i for r and o for w in the pred/succ flags of fence;"          \
+          "Extend fence.i to fence.i + fence.")                                  \
+  product(bool, UseRVV, false, "Use RVV instructions")                           \
+  product(bool, AvoidUnalignedAccesses, true,                                    \
+          "Avoid generating unaligned memory accesses")                          \
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/icBuffer_riscv.cpp
+++ b/src/hotspot/cpu/riscv/icBuffer_riscv.cpp
@@ -47,7 +47,7 @@ void InlineCacheBuffer::assemble_ic_buffer_code(address code_begin, void* cached
   ResourceMark rm;
   CodeBuffer      code(code_begin, ic_stub_code_size());
   MacroAssembler* masm            = new MacroAssembler(&code);
-  // note: even though the code contains an embedded value, we do not need reloc info
+  // Note: even though the code contains an embedded value, we do not need reloc info
   // because
   // (1) the value is old (i.e., doesn't matter for scavenges)
   // (2) these ICStubs are removed *before* a GC happens, so the roots disappear

--- a/src/hotspot/cpu/riscv/icache_riscv.hpp
+++ b/src/hotspot/cpu/riscv/icache_riscv.hpp
@@ -26,14 +26,14 @@
 #ifndef CPU_RISCV_ICACHE_RISCV_HPP
 #define CPU_RISCV_ICACHE_RISCV_HPP
 
-// Interface for updating the instruction cache.  Whenever the VM
+// Interface for updating the instruction cache. Whenever the VM
 // modifies code, part of the processor instruction cache potentially
 // has to be flushed.
 
 class ICache : public AbstractICache {
 public:
   enum {
-    stub_size      = 16,                 // Size of the icache flush stub in bytes
+    stub_size      = 16,                // Size of the icache flush stub in bytes
     line_size      = BytesPerWord,      // conservative
     log2_line_size = LogBytesPerWord    // log2(line_size)
   };

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -223,9 +223,9 @@ void InterpreterMacroAssembler::get_cache_and_index_at_bcp(Register cache,
   assert_different_registers(cache, xcpool);
   get_cache_index_at_bcp(index, bcp_offset, index_size);
   assert(sizeof(ConstantPoolCacheEntry) == 4 * wordSize, "adjust code below");
-  // convert from field index to ConstantPoolCacheEntry
+  // Convert from field index to ConstantPoolCacheEntry
   // riscv64 already has the cache in xcpool so there is no need to
-  // install it in cache. instead we pre-add the indexed offset to
+  // install it in cache. Instead we pre-add the indexed offset to
   // xcpool and return it in cache. All clients of this method need to
   // be modified accordingly.
   slli(cache, index, 5);
@@ -261,7 +261,7 @@ void InterpreterMacroAssembler::get_cache_entry_pointer_at_bcp(Register cache,
   assert(cache != tmp, "must use different register");
   get_cache_index_at_bcp(tmp, bcp_offset, index_size);
   assert(sizeof(ConstantPoolCacheEntry) == 4 * wordSize, "adjust code below");
-  // convert from field index to ConstantPoolCacheEntry index
+  // Convert from field index to ConstantPoolCacheEntry index
   // and from word offset to byte offset
   assert(log2i_exact(in_bytes(ConstantPoolCacheEntry::size_in_bytes())) == 2 + LogBytesPerWord, "else change next line");
   ld(cache, Address(fp, frame::interpreter_frame_cache_offset * wordSize));
@@ -277,7 +277,7 @@ void InterpreterMacroAssembler::load_resolved_reference_at_index(
   assert_different_registers(result, index);
 
   get_constant_pool(result);
-  // load pointer for resolved_references[] objArray
+  // Load pointer for resolved_references[] objArray
   ld(result, Address(result, ConstantPool::cache_offset_in_bytes()));
   ld(result, Address(result, ConstantPoolCache::resolved_references_offset_in_bytes()));
   resolve_oop_handle(result, tmp);
@@ -593,7 +593,7 @@ void InterpreterMacroAssembler::remove_activation(
                                 bool throw_monitor_exception,
                                 bool install_monitor_exception,
                                 bool notify_jvmdi) {
-  // Note: Registers x13 xmm0 may be in use for the
+  // Note: Registers x13 may be in use for the
   // result check if synchronized method
   Label unlocked, unlock, no_unlock;
 
@@ -802,7 +802,7 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg)
 
     Label slow_case;
 
-    // Load object pointer into obj_reg %c_rarg3
+    // Load object pointer into obj_reg c_rarg3
     ld(obj_reg, Address(lock_reg, obj_offset));
 
     if (DiagnoseSyncOnValueBasedClasses != 0) {
@@ -826,13 +826,13 @@ void InterpreterMacroAssembler::lock_object(Register lock_reg)
 
     // Test if the oopMark is an obvious stack pointer, i.e.,
     //  1) (mark & 7) == 0, and
-    //  2) rsp <= mark < mark + os::pagesize()
+    //  2) sp <= mark < mark + os::pagesize()
     //
     // These 3 tests can be done by evaluating the following
-    // expression: ((mark - rsp) & (7 - os::vm_page_size())),
+    // expression: ((mark - sp) & (7 - os::vm_page_size())),
     // assuming both stack pointer and pagesize have their
     // least significant 3 bits clear.
-    // NOTE: the oopMark is in swap_reg %x10 as the result of cmpxchg
+    // NOTE: the oopMark is in swap_reg x10 as the result of cmpxchg
     sub(swap_reg, swap_reg, sp);
     li(t0, (int64_t)(7 - os::vm_page_size()));
     andr(swap_reg, swap_reg, t0);
@@ -880,10 +880,10 @@ void InterpreterMacroAssembler::unlock_object(Register lock_reg)
     save_bcp(); // Save in case of exception
 
     // Convert from BasicObjectLock structure to object and BasicLock
-    // structure Store the BasicLock address into %x10
+    // structure Store the BasicLock address into x10
     la(swap_reg, Address(lock_reg, BasicObjectLock::lock_offset_in_bytes()));
 
-    // Load oop into obj_reg(%c_rarg3)
+    // Load oop into obj_reg(c_rarg3)
     ld(obj_reg, Address(lock_reg, BasicObjectLock::obj_offset_in_bytes()));
 
     // Free entry
@@ -1485,7 +1485,7 @@ void InterpreterMacroAssembler::profile_switch_case(Register index,
   if (ProfileInterpreter) {
     Label profile_continue;
 
-    // if no method data exists, go to profile_continue.
+    // If no method data exists, go to profile_continue.
     test_method_data_pointer(mdp, profile_continue);
 
     // Build the base (index * per_case_size_in_bytes()) +
@@ -1663,8 +1663,8 @@ void InterpreterMacroAssembler::profile_obj_type(Register obj, const Address& md
   xorr(obj, obj, t0);
   andi(t0, obj, TypeEntries::type_klass_mask);
   beqz(t0, next); // klass seen before, nothing to
-                           // do. The unknown bit may have been
-                           // set already but no need to check.
+                  // do. The unknown bit may have been
+                  // set already but no need to check.
 
   andi(t0, obj, TypeEntries::type_unknown);
   bnez(t0, next);
@@ -1896,7 +1896,6 @@ void InterpreterMacroAssembler::profile_parameters_type(Register mdp, Register t
     neg(tmp2, tmp2);
 
     // read the parameter from the local area
-
     slli(tmp2, tmp2, Interpreter::logStackElementSize);
     add(tmp2, tmp2, xlocals);
     ld(tmp2, Address(tmp2, 0));

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1191,7 +1191,7 @@ static int patch_offset_in_jal(address branch, int64_t offset) {
   Assembler::patch(branch, 30, 21, (offset >> 1)  & 0x3ff);                     // offset[10:1]  ==> branch[30:21]
   Assembler::patch(branch, 20, 20, (offset >> 11) & 0x1);                       // offset[11]    ==> branch[20]
   Assembler::patch(branch, 19, 12, (offset >> 12) & 0xff);                      // offset[19:12] ==> branch[19:12]
-  return NativeInstruction::instruction_size;                                             // only one instruction
+  return NativeInstruction::instruction_size;                                   // only one instruction
 }
 
 static int patch_offset_in_conditional_branch(address branch, int64_t offset) {
@@ -2584,7 +2584,7 @@ void MacroAssembler::check_klass_subtype_fast_path(Register sub_klass,
 #undef final_jmp
 }
 
-// scans count pointer sized words at [addr] for occurence of value,
+// Scans count pointer sized words at [addr] for occurence of value,
 // generic
 void MacroAssembler::repne_scan(Register addr, Register value, Register count,
                                 Register temp) {
@@ -2618,7 +2618,7 @@ void MacroAssembler::check_klass_subtype_slow_path(Register sub_klass,
 
   assert(label_nulls <= 1, "at most one NULL in the batch");
 
-  // a couple of usefule fields in sub_klass:
+  // A couple of usefule fields in sub_klass:
   int ss_offset = in_bytes(Klass::secondary_supers_offset());
   int sc_offset = in_bytes(Klass::secondary_super_cache_offset());
   Address secondary_supers_addr(sub_klass, ss_offset);
@@ -3028,7 +3028,7 @@ void MacroAssembler::compute_index(Register haystack, Register trailing_zeros,
 }
 
 // string indexof
-// find pattern element in src, compute match mask,
+// Find pattern element in src, compute match mask,
 // only the first occurrence of 0x80/0x8000 at low bits is the valid match index
 // match mask patterns and corresponding indices would be like:
 // - 0x8080808080808080 (Latin1)
@@ -3045,7 +3045,7 @@ void MacroAssembler::compute_match_mask(Register src, Register pattern, Register
   andr(match_mask, match_mask, src);
 }
 
-// count bits of trailing zero chars from lsb to msb until first non-zero element.
+// Count bits of trailing zero chars from lsb to msb until first non-zero element.
 // For LL case, one byte for one element, so shift 8 bits once, and for other case,
 // shift 16 bits once.
 void MacroAssembler::ctzc_bit(Register Rd, Register Rs, bool isLL, Register Rtmp1, Register Rtmp2)

--- a/src/hotspot/cpu/riscv/matcher_riscv.hpp
+++ b/src/hotspot/cpu/riscv/matcher_riscv.hpp
@@ -35,7 +35,7 @@
   static const bool implements_scalable_vector = true;
 
   static const bool supports_scalable_vector() {
-    return UseVExt;
+    return UseRVV;
   }
 
   // riscv64 supports misaligned vectors store/load.

--- a/src/hotspot/cpu/riscv/methodHandles_riscv.cpp
+++ b/src/hotspot/cpu/riscv/methodHandles_riscv.cpp
@@ -190,7 +190,7 @@ address MethodHandles::generate_method_handle_interpreter_entry(MacroAssembler* 
 
   // x30: sender SP (must preserve; see prepare_to_jump_from_interpreted)
   // xmethod: Method*
-  // x13: argument locator (parameter slot count, added to rsp)
+  // x13: argument locator (parameter slot count, added to sp)
   // x11: used as temp to hold mh or receiver
   // x10, x29: garbage temps, blown away
   Register argp   = x13;   // argument list ptr, live on error paths

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1776,9 +1776,9 @@ const bool Matcher::match_rule_supported(int opcode) {
     case Op_StrCompressedCopy: // fall through
     case Op_StrInflatedCopy:   // fall through
     case Op_HasNegatives:
-      return UseVExt;
+      return UseRVV;
     case Op_EncodeISOArray:
-      return UseVExt && SpecialEncodeISOArray;
+      return UseRVV && SpecialEncodeISOArray;
   }
 
   return true; // Per default match rules are supported.
@@ -1841,8 +1841,8 @@ bool Matcher::is_short_branch_offset(int rule, int br_size, int offset) {
 
 // Vector width in bytes.
 const int Matcher::vector_width_in_bytes(BasicType bt) {
-  if (UseVExt) {
-    // The MaxVectorSize should have been set by detecting RVV max vector register size when check UseVExt.
+  if (UseRVV) {
+    // The MaxVectorSize should have been set by detecting RVV max vector register size when check UseRVV.
     // MaxVectorSize == VM_Version::_initial_vector_length
     return MaxVectorSize;
   }
@@ -1860,7 +1860,7 @@ const int Matcher::min_vector_size(const BasicType bt) {
 // Vector ideal reg.
 const uint Matcher::vector_ideal_reg(int len) {
   assert(MaxVectorSize >= len, "");
-  if (UseVExt) {
+  if (UseRVV) {
     return Op_VecA;
   }
 
@@ -9913,7 +9913,7 @@ instruct partialSubtypeCheckVsZero(iRegP_R14 sub, iRegP_R10 super, iRegP_R12 tem
 instruct string_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
                          iRegI_R10 result, iRegP_R28 tmp1, iRegL_R29 tmp2, iRegL_R30 tmp3, rFlagsReg cr)
 %{
-  predicate(!UseVExt && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU);
+  predicate(!UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, KILL tmp3, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
@@ -9931,7 +9931,7 @@ instruct string_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R
 instruct string_compareL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
                          iRegI_R10 result, iRegP_R28 tmp1, iRegL_R29 tmp2, iRegL_R30 tmp3, rFlagsReg cr)
 %{
-  predicate(!UseVExt && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LL);
+  predicate(!UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, KILL tmp3, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
@@ -9948,7 +9948,7 @@ instruct string_compareL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R
 instruct string_compareUL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_R14 cnt2,
                           iRegI_R10 result, iRegP_R28 tmp1, iRegL_R29 tmp2, iRegL_R30 tmp3, rFlagsReg cr)
 %{
-  predicate(!UseVExt && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UL);
+  predicate(!UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UL);
   match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, KILL tmp3, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
@@ -9966,7 +9966,7 @@ instruct string_compareLU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_
                           iRegI_R10 result, iRegP_R28 tmp1, iRegL_R29 tmp2, iRegL_R30 tmp3,
                           rFlagsReg cr)
 %{
-  predicate(!UseVExt && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LU);
+  predicate(!UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LU);
   match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, KILL tmp3, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2, KILL cr);
 
@@ -10111,7 +10111,7 @@ instruct stringU_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
                               iRegINoSp tmp3, iRegINoSp tmp4, rFlagsReg tmp)
 %{
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
-  predicate(!UseVExt && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::U));
+  predicate(!UseRVV && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::U));
   effect(USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP_DEF result,
          TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, KILL tmp);
 
@@ -10131,7 +10131,7 @@ instruct stringL_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
                               iRegINoSp tmp3, iRegINoSp tmp4, rFlagsReg tmp)
 %{
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
-  predicate(!UseVExt && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::L));
+  predicate(!UseRVV && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::L));
   effect(USE_KILL str1, USE_KILL cnt1, USE_KILL ch, TEMP_DEF result,
          TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, KILL tmp);
 
@@ -10148,7 +10148,7 @@ instruct stringL_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
 // clearing of an array
 instruct clearArray_reg_reg(iRegL_R29 cnt, iRegP_R28 base, Universe dummy, rFlagsReg cr)
 %{
-  predicate(!UseVExt);
+  predicate(!UseRVV);
   match(Set dummy (ClearArray cnt base));
   effect(USE_KILL cnt, USE_KILL base);
 
@@ -10168,7 +10168,7 @@ instruct clearArray_reg_reg(iRegL_R29 cnt, iRegP_R28 base, Universe dummy, rFlag
 
 instruct clearArray_imm_reg(immL cnt, iRegP_R28 base, Universe dummy, rFlagsReg cr)
 %{
-  predicate(!UseVExt && (uint64_t)n->in(2)->get_long()
+  predicate(!UseRVV && (uint64_t)n->in(2)->get_long()
             < (uint64_t)(BlockZeroingLowLimit >> LogBytesPerWord));
   match(Set dummy (ClearArray cnt base));
   effect(USE_KILL base, KILL cr);
@@ -10186,7 +10186,7 @@ instruct clearArray_imm_reg(immL cnt, iRegP_R28 base, Universe dummy, rFlagsReg 
 instruct string_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
                         iRegI_R10 result, rFlagsReg cr)
 %{
-  predicate(!UseVExt && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::LL);
+  predicate(!UseRVV && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrEquals (Binary str1 str2) cnt));
   effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, KILL cr);
 
@@ -10202,7 +10202,7 @@ instruct string_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
 instruct string_equalsU(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
                         iRegI_R10 result, rFlagsReg cr)
 %{
-  predicate(!UseVExt && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::UU);
+  predicate(!UseRVV && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (StrEquals (Binary str1 str2) cnt));
   effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, KILL cr);
 
@@ -10219,7 +10219,7 @@ instruct array_equalsB(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
                        iRegP_R13 tmp1, iRegP_R14 tmp2, iRegP_R15 tmp3,
                        iRegP_R16 tmp4, iRegP_R28 tmp, rFlagsReg cr)
 %{
-  predicate(!UseVExt && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
+  predicate(!UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (AryEq ary1 ary2));
   effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, KILL cr);
 
@@ -10236,7 +10236,7 @@ instruct array_equalsC(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
                        iRegP_R13 tmp1, iRegP_R14 tmp2, iRegP_R15 tmp3,
                        iRegP_R16 tmp4, iRegP_R28 tmp, rFlagsReg cr)
 %{
-  predicate(!UseVExt && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
+  predicate(!UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (AryEq ary1 ary2));
   effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP tmp1, TEMP tmp2, TEMP tmp3, TEMP tmp4, KILL cr);
 

--- a/src/hotspot/cpu/riscv/riscv_vext.ad
+++ b/src/hotspot/cpu/riscv/riscv_vext.ad
@@ -90,7 +90,7 @@ source %{
       case Op_VectorTest:
         return false;
       default:
-        return UseVExt;
+        return UseRVV;
     }
   }
 
@@ -1812,7 +1812,7 @@ instruct vstring_equalsL(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
                          iRegI_R10 result, vReg_V1 v1,
                          vReg_V2 v2, vReg_V3 v3, rFlagsReg r6)
 %{
-  predicate(UseVExt && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::LL);
+  predicate(UseRVV && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (StrEquals (Binary str1 str2) cnt));
   effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, KILL r6, TEMP v1, TEMP v2, TEMP v3);
 
@@ -1829,7 +1829,7 @@ instruct vstring_equalsU(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
                          iRegI_R10 result, vReg_V1 v1,
                          vReg_V2 v2, vReg_V3 v3, rFlagsReg r6)
 %{
-  predicate(UseVExt && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::UU);
+  predicate(UseRVV && ((StrEqualsNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (StrEquals (Binary str1 str2) cnt));
   effect(USE_KILL str1, USE_KILL str2, USE_KILL cnt, KILL r6, TEMP v1, TEMP v2, TEMP v3);
 
@@ -1845,7 +1845,7 @@ instruct vstring_equalsU(iRegP_R11 str1, iRegP_R13 str2, iRegI_R14 cnt,
 instruct varray_equalsB(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
                         vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegP_R28 tmp, rFlagsReg r6)
 %{
-  predicate(UseVExt && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
+  predicate(UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result (AryEq ary1 ary2));
   effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v1, TEMP v2, TEMP v3, KILL r6);
 
@@ -1860,7 +1860,7 @@ instruct varray_equalsB(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
 instruct varray_equalsC(iRegP_R11 ary1, iRegP_R12 ary2, iRegI_R10 result,
                         vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegP_R28 tmp, rFlagsReg r6)
 %{
-  predicate(UseVExt && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
+  predicate(UseRVV && ((AryEqNode*)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result (AryEq ary1 ary2));
   effect(KILL tmp, USE_KILL ary1, USE_KILL ary2, TEMP v1, TEMP v2, TEMP v3, KILL r6);
 
@@ -1876,7 +1876,7 @@ instruct vstring_compareU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_
                           iRegI_R10 result, vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
-  predicate(UseVExt && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU);
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UU);
   match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
          TEMP v1, TEMP v2, TEMP v3, TEMP v4, TEMP v5);
@@ -1895,7 +1895,7 @@ instruct vstring_compareL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI_
                           iRegI_R10 result, vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
                           iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
-  predicate(UseVExt && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LL);
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LL);
   match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
          TEMP v1, TEMP v2, TEMP v3, TEMP v4, TEMP v5);
@@ -1914,7 +1914,7 @@ instruct vstring_compareUL(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI
                            iRegI_R10 result, vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
                            iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
-  predicate(UseVExt && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UL);
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::UL);
   match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
          TEMP v1, TEMP v2, TEMP v3, TEMP v4, TEMP v5);
@@ -1932,7 +1932,7 @@ instruct vstring_compareLU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI
                            iRegI_R10 result, vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, vReg_V4 v4, vReg_V5 v5,
                            iRegP_R28 tmp1, iRegL_R29 tmp2)
 %{
-  predicate(UseVExt && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LU);
+  predicate(UseRVV && ((StrCompNode *)n)->encoding() == StrIntrinsicNode::LU);
   match(Set result(StrComp(Binary str1 cnt1)(Binary str2 cnt2)));
   effect(KILL tmp1, KILL tmp2, USE_KILL str1, USE_KILL str2, USE_KILL cnt1, USE_KILL cnt2,
          TEMP v1, TEMP v2, TEMP v3, TEMP v4, TEMP v5);
@@ -1951,7 +1951,7 @@ instruct vstring_compareLU(iRegP_R11 str1, iRegI_R12 cnt1, iRegP_R13 str2, iRegI
 instruct vstring_inflate(Universe dummy, iRegP_R10 src, iRegP_R11 dst, iRegI_R12 len,
                          vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegL tmp)
 %{
-  predicate(UseVExt);
+  predicate(UseRVV);
   match(Set dummy (StrInflatedCopy src (Binary dst len)));
   effect(TEMP v1, TEMP v2, TEMP v3, TEMP tmp, USE_KILL src, USE_KILL dst, USE_KILL len);
 
@@ -1966,7 +1966,7 @@ instruct vstring_inflate(Universe dummy, iRegP_R10 src, iRegP_R11 dst, iRegI_R12
 instruct vencode_iso_array(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10 result,
                            vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegL tmp)
 %{
-  predicate(UseVExt);
+  predicate(UseRVV);
   match(Set result (EncodeISOArray src (Binary dst len)));
   effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
          TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
@@ -1983,7 +1983,7 @@ instruct vencode_iso_array(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R1
 instruct vstring_compress(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10 result,
                           vReg_V1 v1, vReg_V2 v2, vReg_V3 v3, iRegL tmp)
 %{
-  predicate(UseVExt);
+  predicate(UseRVV);
   match(Set result (StrCompressedCopy src (Binary dst len)));
   effect(TEMP_DEF result, USE_KILL src, USE_KILL dst, USE_KILL len,
          TEMP v1, TEMP v2, TEMP v3, TEMP tmp);
@@ -1998,7 +1998,7 @@ instruct vstring_compress(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10
 
 instruct vhas_negatives(iRegP_R11 ary1, iRegI_R12 len, iRegI_R10 result, iRegL tmp)
 %{
-  predicate(UseVExt);
+  predicate(UseRVV);
   match(Set result (HasNegatives ary1 len));
   effect(USE_KILL ary1, USE_KILL len, TEMP tmp);
   format %{ "has negatives byte[] $ary1,$len -> $result" %}
@@ -2012,7 +2012,7 @@ instruct vstringU_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
                                iRegI_R10 result, iRegINoSp tmp1, iRegINoSp tmp2,
                                vReg_V1 v1, vReg_V2 v2, vReg_V3 v3)
 %{
-  predicate(UseVExt && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::U));
+  predicate(UseRVV && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::U));
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
   effect(TEMP_DEF result, USE_KILL str1, USE_KILL cnt1, USE_KILL ch,
          TEMP tmp1, TEMP tmp2, TEMP v1, TEMP v2, TEMP v3);
@@ -2032,7 +2032,7 @@ instruct vstringL_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
                                iRegI_R10 result, iRegINoSp tmp1, iRegINoSp tmp2,
                                vReg_V1 v1, vReg_V2 v2, vReg_V3 v3)
 %{
-  predicate(UseVExt && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::L));
+  predicate(UseRVV && (((StrIndexOfCharNode*)n)->encoding() == StrIntrinsicNode::L));
   match(Set result (StrIndexOfChar (Binary str1 cnt1) ch));
   effect(TEMP_DEF result, USE_KILL str1, USE_KILL cnt1, USE_KILL ch,
          TEMP tmp1, TEMP tmp2, TEMP v1, TEMP v2, TEMP v3);
@@ -2052,7 +2052,7 @@ instruct vstringL_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
 instruct vclearArray_reg_reg(iRegL_R29 cnt, iRegP_R28 base, Universe dummy,
                              vReg_V1 vReg1, vReg_V2 vReg2, vReg_V3 vReg3)
 %{
-  predicate(UseVExt);
+  predicate(UseRVV);
   match(Set dummy (ClearArray cnt base));
   effect(USE_KILL cnt, USE_KILL base, TEMP vReg1, TEMP vReg2, TEMP vReg3);
 

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -82,7 +82,7 @@ public:
 class RegisterSaver {
   const bool _save_vectors;
  public:
-  RegisterSaver(bool save_vectors) : _save_vectors(UseVExt && save_vectors) {}
+  RegisterSaver(bool save_vectors) : _save_vectors(UseRVV && save_vectors) {}
   ~RegisterSaver() {}
   OopMap* save_live_registers(MacroAssembler* masm, int additional_frame_words, int* total_frame_words);
   void restore_live_registers(MacroAssembler* masm);
@@ -1895,7 +1895,7 @@ void SharedRuntime::generate_deopt_blob() {
   // In the case of an exception pending when deoptimizing, we enter
   // with a return address on the stack that points after the call we patched
   // into the exception handler. We have the following register state from,
-  // e.g., the forward exception stub (see stubGenerator_riscv64.cpp).
+  // e.g., the forward exception stub (see stubGenerator_riscv.cpp).
   //    x10: exception oop
   //    x9: exception handler
   //    x13: throwing pc
@@ -2254,7 +2254,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   OopMap* map = new OopMap(SimpleRuntimeFrame::framesize, 0);
   assert_cond(oop_maps != NULL && map != NULL);
 
-  // location of rfp is known implicitly by the frame sender code
+  // location of fp is known implicitly by the frame sender code
 
   oop_maps->add_gc_map(__ pc() - start, map);
 
@@ -2612,12 +2612,10 @@ RuntimeStub* SharedRuntime::make_native_invoker(address call_target,
   return nullptr;
 }
 
-// This is here instead of runtime_riscv64.cpp because it uses SimpleRuntimeFrame
-//
 //------------------------------generate_exception_blob---------------------------
 // creates exception blob at the end
 // Using exception blob, this code is jumped from a compiled method.
-// (see emit_exception_handler in riscv64.ad file)
+// (see emit_exception_handler in riscv.ad file)
 //
 // Given an exception pc at a call we call into the runtime for the
 // handler in this method. This handler might merely restore state

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -393,7 +393,7 @@ class StubGenerator: public StubCodeGenerator {
   // Note: Usually the parameters are removed by the callee. In case
   // of an exception crossing an activation frame boundary, that is
   // not the case if the callee is compiled code => need to setup the
-  // rsp.
+  // sp.
   //
   // x10: exception oop
 
@@ -886,7 +886,7 @@ class StubGenerator: public StubCodeGenerator {
 
   void copy_memory(bool is_aligned, Register s, Register d,
                    Register count, Register tmp, int step) {
-    if (UseVExt) {
+    if (UseRVV) {
       return copy_memory_v(s, d, count, tmp, step);
     }
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -107,11 +107,7 @@ void VM_Version::get_processor_features() {
     if (!(_features & CPU_V)) {
       warning("RVV is not supported on this CPU");
       FLAG_SET_DEFAULT(UseRVV, false);
-    } else if (!UnlockExperimentalVMOptions) {
-      vm_exit_during_initialization("UseRVV is only available as experimental option on this "
-                                    "platform. It must be enabled via -XX:+UnlockExperimentalVMOptions flag.");
     } else {
-      warning("UseRVV is only available as experimental option on this platform.");
       // read vector length from vector CSR vlenb
       _initial_vector_length = get_current_vector_length();
     }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -103,11 +103,15 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
   }
 
-  if (UseVExt) {
+  if (UseRVV) {
     if (!(_features & CPU_V)) {
       warning("RVV is not supported on this CPU");
-      FLAG_SET_DEFAULT(UseVExt, false);
+      FLAG_SET_DEFAULT(UseRVV, false);
+    } else if (!UnlockExperimentalVMOptions) {
+      vm_exit_during_initialization("UseRVV is only available as experimental option on this "
+                                    "platform. It must be enabled via -XX:+UnlockExperimentalVMOptions flag.");
     } else {
+      warning("UseRVV is only available as experimental option on this platform.");
       // read vector length from vector CSR vlenb
       _initial_vector_length = get_current_vector_length();
     }
@@ -132,20 +136,20 @@ void VM_Version::get_c2_processor_features() {
     FLAG_SET_DEFAULT(ConditionalMoveLimit, 0);
   }
 
-  if (!UseVExt) {
+  if (!UseRVV) {
     FLAG_SET_DEFAULT(SpecialEncodeISOArray, false);
   }
 
-  if (!UseVExt && MaxVectorSize) {
+  if (!UseRVV && MaxVectorSize) {
     FLAG_SET_DEFAULT(MaxVectorSize, 0);
   }
 
-  if (UseVExt) {
+  if (UseRVV) {
     if (FLAG_IS_DEFAULT(MaxVectorSize)) {
       MaxVectorSize = _initial_vector_length;
     } else if (MaxVectorSize < 16) {
       warning("RVV does not support vector length less than 16 bytes. Disabling RVV.");
-      UseVExt = false;
+      UseRVV = false;
     } else if (is_power_of_2(MaxVectorSize)) {
       if (MaxVectorSize > _initial_vector_length) {
         warning("Current system only supports max RVV vector length %d. Set MaxVectorSize to %d",

--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -47,9 +47,9 @@ public:
     decl(A,            "A",            0)     \
     decl(F,            "F",            5)     \
     decl(D,            "D",            3)     \
-    decl(B,            "B",            1)     \
     decl(C,            "C",            2)     \
-    decl(V,            "V",           21)
+    decl(V,            "V",           21)     \
+    decl(B,            "B",            1)
 
 #define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1 << bit),
     CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -52,16 +52,16 @@
 #define HWCAP_ISA_D  (1 << ('D' - 'A'))
 #endif
 
-#ifndef HWCAP_ISA_B
-#define HWCAP_ISA_B  (1 << ('B' - 'A'))
-#endif
-
 #ifndef HWCAP_ISA_C
 #define HWCAP_ISA_C  (1 << ('C' - 'A'))
 #endif
 
 #ifndef HWCAP_ISA_V
 #define HWCAP_ISA_V  (1 << ('V' - 'A'))
+#endif
+
+#ifndef HWCAP_ISA_B
+#define HWCAP_ISA_B  (1 << ('B' - 'A'))
 #endif
 
 #define read_csr(csr)                                           \
@@ -88,16 +88,16 @@ void VM_Version::get_cpu_info() {
   static_assert(CPU_A == HWCAP_ISA_A, "Flag CPU_A must follow Linux HWCAP");
   static_assert(CPU_F == HWCAP_ISA_F, "Flag CPU_F must follow Linux HWCAP");
   static_assert(CPU_D == HWCAP_ISA_D, "Flag CPU_D must follow Linux HWCAP");
-  static_assert(CPU_B == HWCAP_ISA_B, "Flag CPU_B must follow Linux HWCAP");
   static_assert(CPU_C == HWCAP_ISA_C, "Flag CPU_C must follow Linux HWCAP");
   static_assert(CPU_V == HWCAP_ISA_V, "Flag CPU_V must follow Linux HWCAP");
+  static_assert(CPU_B == HWCAP_ISA_B, "Flag CPU_B must follow Linux HWCAP");
   _features = auxv & (
       HWCAP_ISA_I |
       HWCAP_ISA_M |
       HWCAP_ISA_A |
       HWCAP_ISA_F |
       HWCAP_ISA_D |
-      HWCAP_ISA_B |
       HWCAP_ISA_C |
-      HWCAP_ISA_V);
+      HWCAP_ISA_V |
+      HWCAP_ISA_B);
 }


### PR DESCRIPTION
Currently, riscv port supports vector operations which is fully compatible with vector extension 1.0 spec. And we have passed tier 1-4 tests with option "-XX:+UseVExt" with QEMU.

Due to lack of native environment which supports vector extension 1.0, we cannot carry out tests for vector operations on real hardware. So we decided to move port-specific option UseVExt from product to experimental for now, and rename UseVExt to UseRVV.

This also fixes some typos in comments, and  removes unused v extension instructions.

The test results on HiFive Unleashed board (rv64imafdc) and NeZha D1 board (rv64imafdcvu) are in line with expectations.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277440](https://bugs.openjdk.java.net/browse/JDK-8277440): riscv: Move UseVExt from product to experimental


### Reviewers
 * [Yadong Wang](https://openjdk.java.net/census#yadongwang) (@yadongw - Author)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/11.diff">https://git.openjdk.java.net/riscv-port/pull/11.diff</a>

</details>
