### PR TITLE
8277431: riscv: Intrinsify recursive ObjectMonitor locking for C2

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2359,6 +2359,16 @@ encode %{
     __ mv(tmp, (address)markWord::unused_mark().value());
     __ sd(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
+    __ beqz(flag, cont); // CAS success means locking succeeded
+
+    __ bne(flag, xthread, cont); // Check for recursive locking
+
+    // Recursive lock case
+    __ mv(flag, zr);
+    __ ld(tmp, Address(disp_hdr, ObjectMonitor::recursions_offset_in_bytes() - markWord::monitor_value));
+    __ add(tmp, tmp, 1u);
+    __ sd(tmp, Address(disp_hdr, ObjectMonitor::recursions_offset_in_bytes() - markWord::monitor_value));
+
     __ bind(cont);
   %}
 
@@ -2404,10 +2414,19 @@ encode %{
     __ add(tmp, tmp, -(int)markWord::monitor_value); // monitor
     __ ld(flag, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
     __ ld(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
+
+    Label notRecursive;
     __ xorr(flag, flag, xthread); // Will be 0 if we are the owner.
-    __ orr(flag, flag, disp_hdr); // Will be 0 if there are 0 recursions
     __ bnez(flag, cont);
 
+    __ beqz(disp_hdr, notRecursive); // Will be 0 if not recursive.
+
+    // Recursive lock
+    __ addi(disp_hdr, disp_hdr, -1);
+    __ sd(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
+    __ j(cont);
+
+    __ bind(notRecursive);
     __ ld(flag, Address(tmp, ObjectMonitor::EntryList_offset_in_bytes()));
     __ ld(disp_hdr, Address(tmp, ObjectMonitor::cxq_offset_in_bytes()));
     __ orr(flag, flag, disp_hdr); // Will be 0 if both are 0.


### PR DESCRIPTION
According to https://bugs.openjdk.java.net/browse/JDK-8277180, the C2 fast_lock and fast_unlock intrinsics don't support recursive ObjectMonitor locking. Some workload can significantly benefit from this. This fixes the problem on riscv.

Tier1 tests of hotspot and jdk are passed on unmatched and all JTreg tests are tested on qemu without new failures.

[The original performance regression after JDK-8253064](https://bugs.openjdk.java.net/browse/JDK-8263864) was resolved by this intrinsic. 
The benchmark ran on unmatched:
```
dacapo-9.12-MR1-bach.jar h2 -s huge -t 1 -n 1
```
Non-intrisified recursive fast_lock/fast_unlock:
===== DaCapo 9.12-MR1 h2 PASSED in 2614652 msec =====
Intrisified recursive fast_lock/fast_unlock:
===== DaCapo 9.12-MR1 h2 PASSED in 2027247 msec =====

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277431](https://bugs.openjdk.java.net/browse/JDK-8277431): riscv: Intrinsify recursive ObjectMonitor locking for C2


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/13.diff">https://git.openjdk.java.net/riscv-port/pull/13.diff</a>

</details>
