### PR TITLE
8277877: C2 fast_unlock intrinsic on riscv has unnecessary ownership check

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2412,18 +2412,15 @@ encode %{
     __ bind(object_has_monitor);
     STATIC_ASSERT(markWord::monitor_value <= INT_MAX);
     __ add(tmp, tmp, -(int)markWord::monitor_value); // monitor
-    __ ld(flag, Address(tmp, ObjectMonitor::owner_offset_in_bytes()));
     __ ld(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
 
     Label notRecursive;
-    __ xorr(flag, flag, xthread); // Will be 0 if we are the owner.
-    __ bnez(flag, cont);
-
     __ beqz(disp_hdr, notRecursive); // Will be 0 if not recursive.
 
     // Recursive lock
     __ addi(disp_hdr, disp_hdr, -1);
     __ sd(disp_hdr, Address(tmp, ObjectMonitor::recursions_offset_in_bytes()));
+    __ mv(flag, zr);
     __ j(cont);
 
     __ bind(notRecursive);


### PR DESCRIPTION
It's an optional, maybe only for debug, to check the owner of the lock in the fast_unlock intrinsic in riscv, which already applied in AArch64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277877](https://bugs.openjdk.java.net/browse/JDK-8277877): C2 fast_unlock intrinsic on riscv has unnecessary ownership check


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/14.diff">https://git.openjdk.java.net/riscv-port/pull/14.diff</a>

</details>
