### PR TITLE
8277884: riscv: Fix cmpxchg_narrow_value that needs to sign-extend non-bool results

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2328,6 +2328,13 @@ void MacroAssembler::cmpxchg_narrow_value(Register addr, Register expected,
 
     bind(fail);
     srl(result, tmp, shift);
+
+    if (size == int8) {
+      sign_ext(result, result, registerSize - 8);
+    } else {
+      // size == int16 case
+      sign_ext(result, result, registerSize - 16);
+    }
   }
 }
 


### PR DESCRIPTION
Hi team,

According to https://bugs.openjdk.java.net/browse/JDK-8277884 and [the original patch](https://github.com/riscv-collab/riscv-openjdk/pull/9):

A very simple program inherited from jcstress could reproduce this:

```
import java.lang.invoke.MethodHandles;
import java.lang.invoke.VarHandle;

// run with:
// build/linux-riscv64-server-release/images/jdk/bin/java -ea -XX:-TieredCompilation -XX:CompileCommand=compileonly,jdk.internal.misc.Unsafe::compareAndSetByte TestCASByte
// assert will fail.
// if we add '-XX:+UnlockDiagnosticVMOptions -XX:DisableIntrinsic=_compareAndExchangeByte' this test will pass.

public class TestCASByte {

    byte[] array = new byte[1];

    static final VarHandle vh;
    static {
        try {
            vh = MethodHandles.arrayElementVarHandle(byte[].class);
        } catch (Exception e) {
            throw new RuntimeException(e);
        }
    }

    public void test() {
        for (int i = 0; i < 100_000; i++) { // To level 4
            // clear
            array[0] = 0;

            byte res1 = (byte)vh.getAndSet(array, 0, (byte)-1);
            byte res2 = (byte)vh.getAndSet(array, 0, (byte)2);

            assert res1 == 0 && res2 == -1;
        }
    }

    public static void main(String[] args) {
        new TestCASByte().test();
    }

}
```

In this case when we are getting the `-1` value saved in memory, the shift is `0`, the old is `0x00000000000000ff` and the mask is `0x00000000000000ff` at the end of cmpxchg_narrow_value. The final result is `0x00000000000000ff` but it indeed should be `0xffffffffffffffff`. Therefore, if the result is negative, we need to make a sign extension.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277884](https://bugs.openjdk.java.net/browse/JDK-8277884): riscv: Fix cmpxchg_narrow_value that needs to sign-extend non-bool results


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/15.diff">https://git.openjdk.java.net/riscv-port/pull/15.diff</a>

</details>
