### PR TITLE
8277883: riscv: Fix a temp register usage in eden_allocate

### DIFF
--- a/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/barrierSetAssembler_riscv.cpp
@@ -181,9 +181,9 @@ void BarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register obj,
 
     // Get the current top of the heap
     ExternalAddress address_top((address) Universe::heap()->top_addr());
-    __ la_patchable(t2, address_top, offset);
-    __ addi(t2, t2, offset);
-    __ lr_d(obj, t2, Assembler::aqrl);
+    __ la_patchable(t0, address_top, offset);
+    __ addi(t0, t0, offset);
+    __ lr_d(obj, t0, Assembler::aqrl);
 
     // Adjust it my the size of our new object
     if (var_size_in_bytes == noreg) {
@@ -205,7 +205,7 @@ void BarrierSetAssembler::eden_allocate(MacroAssembler* masm, Register obj,
     __ bgtu(end, heap_end, slow_case, is_far);
 
     // If heap_top hasn't been changed by some other thread, update it.
-    __ sc_d(t1, end, t2, Assembler::rl);
+    __ sc_d(t1, end, t0, Assembler::rl);
     __ bnez(t1, retry);
     incr_allocated_bytes(masm, var_size_in_bytes, con_size_in_bytes, tmp1);
   }


### PR DESCRIPTION
Hi team,

A trivial fix for a small C1 crash - this issue could be directly reproduced by using `java -XX:+UseSerialGC -XX:-UseTLAB -XX:TieredStopAtLevel=1`. The reason is simple: the eden_allocate uses t2 as a register and zaps it, whereas C1 will use it as a register allocation candidate, leading to a crash. In this function, t0 never gets a use so we can use it safely. Tested in all cases. [The original patch](https://github.com/riscv-collab/riscv-openjdk/pull/15)

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8277883](https://bugs.openjdk.java.net/browse/JDK-8277883): riscv: Fix a temp register usage in eden_allocate


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/16/head:pull/16` \
`$ git checkout pull/16`

Update a local copy of the PR: \
`$ git checkout pull/16` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/16/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 16`

View PR using the GUI difftool: \
`$ git pr show -t 16`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/16.diff">https://git.openjdk.java.net/riscv-port/pull/16.diff</a>

</details>
