### PR TITLE
8277968: riscv: Detect vector extension with vcsr

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -39,6 +39,14 @@ public:
 
   constexpr static bool supports_stack_watermark_barrier() { return true; }
 
+  static bool is_checkvext_fault(address pc) {
+    return pc != NULL && (pc == _checkvext_fault_pc || pc == _checkvext_fault_pc2);
+  }
+
+  static address continuation_for_checkvext_fault(address pc) {
+    assert(_checkvext_continuation_pc != NULL, "not initialized");
+    return _checkvext_continuation_pc;
+  }
 
   enum Feature_Flag {
 #define CPU_FEATURE_FLAGS(decl)               \
@@ -58,9 +66,11 @@ public:
 
 protected:
   static uint32_t _initial_vector_length;
+  static address _checkvext_fault_pc;
+  static address _checkvext_fault_pc2;
+  static address _checkvext_continuation_pc;
   static void get_processor_features();
   static void get_cpu_info();
-  static uint32_t get_current_vector_length();
 
 #ifdef COMPILER2
 private:

--- a/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/os_linux_riscv.cpp
@@ -202,6 +202,11 @@ bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
       }
     }
 
+    if (sig == SIGILL && VM_Version::is_checkvext_fault(pc)) {
+      os::Posix::ucontext_set_pc(uc, VM_Version::continuation_for_checkvext_fault(pc));
+      return true;
+    }
+
     if (thread->thread_state() == _thread_in_Java) {
       // Java thread running in Java code => find exception handler if any
       // a fault inside compiled code, the interpreter, or a stub

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -74,11 +74,6 @@
         __v;                                                    \
 })
 
-uint32_t VM_Version::get_current_vector_length() {
-  assert(_features & CPU_V, "should not call this");
-  return (uint32_t)read_csr(CSR_VLENB);
-}
-
 void VM_Version::get_cpu_info() {
 
   uint64_t auxv = getauxval(AT_HWCAP);


### PR DESCRIPTION
UseRVV could cause crash on D1 board(RISCV-C906).

It seems that though the D1 board is equipped with RVV-0.7.1[1] . In our test, VLENB CSR can return value of 16 on D1 board. So JDK will assume it can support RVV extension and crash in vector instructions when  UseRVV is enabled.  

RVV-0.9 and above[2] introduce a new VCSR CSR register, it will raise SIGILL on D1 board. So we can check it to detect vext support.


[1] https://github.com/riscv/riscv-v-spec/blob/0a24d0f61b5cd3f1f9265e8c40ab211daa865ede/v-spec.adoc#vector-extension-programmers-model
[2] https://github.com/riscv/riscv-v-spec/blob/master/v-spec.adoc#vector-extension-programmers-model

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8277968](https://bugs.openjdk.java.net/browse/JDK-8277968): riscv: Detect vector extension with vcsr


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/18/head:pull/18` \
`$ git checkout pull/18`

Update a local copy of the PR: \
`$ git checkout pull/18` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/18/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 18`

View PR using the GUI difftool: \
`$ git pr show -t 18`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/18.diff">https://git.openjdk.java.net/riscv-port/pull/18.diff</a>

</details>
