### PR TITLE
8278033: riscv: Fix MacroAssembler::atomic_incw: store condition instruction has wrong operand order

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2479,7 +2479,7 @@ void MacroAssembler::atomic_incw(Register counter_addr, Register tmp) {
   lr_w(tmp, counter_addr);
   addw(tmp, tmp, 1);
   // if we store+flush with no intervening write tmp wil be zero
-  sc_w(tmp, counter_addr, tmp);
+  sc_w(tmp, tmp, counter_addr);
   bnez(tmp, retry_load);
 }
 


### PR DESCRIPTION
This is a trivial fix for this typo. This could reproduce before JDK18 by using `-XX:+PrintBiasedLockingStatistics`; however, after the removal of BiasedLocking, this function has no usage now. But we might fix it as well for future usage since it is a quite fundamental function. [The original patch](https://github.com/riscv-collab/riscv-openjdk/pull/11)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278033](https://bugs.openjdk.java.net/browse/JDK-8278033): riscv: Fix MacroAssembler::atomic_incw: store condition instruction has wrong operand order


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/19.diff">https://git.openjdk.java.net/riscv-port/pull/19.diff</a>

</details>
