### PR TITLE
8278034: riscv: Fix callee-saved float register definitions: should be SOE

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -157,9 +157,9 @@ reg_def R31_H   ( SOC, SOC, Op_RegI, 31, x31->as_VMReg()->next());
 // RISCV64 has 32 floating-point registers. Each can store a single
 // or double precision floating-point value.
 
-// for Java use float registers v0-v15 are always save on call whereas
-// the platform ABI treats v8-v15 as callee save). float registers
-// v16-v31 are SOC as per the platform spec
+// for Java use float registers f0-f31 are always save on call whereas
+// the platform ABI treats f8-f9 and f18-f27 as callee save). Other
+// float registers are SOC as per the platform spec
 
 reg_def F0    ( SOC, SOC, Op_RegF,  0,  f0->as_VMReg()          );
 reg_def F0_H  ( SOC, SOC, Op_RegF,  0,  f0->as_VMReg()->next()  );
@@ -177,10 +177,10 @@ reg_def F6    ( SOC, SOC, Op_RegF,  6,  f6->as_VMReg()          );
 reg_def F6_H  ( SOC, SOC, Op_RegF,  6,  f6->as_VMReg()->next()  );
 reg_def F7    ( SOC, SOC, Op_RegF,  7,  f7->as_VMReg()          );
 reg_def F7_H  ( SOC, SOC, Op_RegF,  7,  f7->as_VMReg()->next()  );
-reg_def F8    ( SOC, SOC, Op_RegF,  8,  f8->as_VMReg()          );
-reg_def F8_H  ( SOC, SOC, Op_RegF,  8,  f8->as_VMReg()->next()  );
-reg_def F9    ( SOC, SOC, Op_RegF,  9,  f9->as_VMReg()          );
-reg_def F9_H  ( SOC, SOC, Op_RegF,  9,  f9->as_VMReg()->next()  );
+reg_def F8    ( SOC, SOE, Op_RegF,  8,  f8->as_VMReg()          );
+reg_def F8_H  ( SOC, SOE, Op_RegF,  8,  f8->as_VMReg()->next()  );
+reg_def F9    ( SOC, SOE, Op_RegF,  9,  f9->as_VMReg()          );
+reg_def F9_H  ( SOC, SOE, Op_RegF,  9,  f9->as_VMReg()->next()  );
 reg_def F10   ( SOC, SOC, Op_RegF,  10, f10->as_VMReg()         );
 reg_def F10_H ( SOC, SOC, Op_RegF,  10, f10->as_VMReg()->next() );
 reg_def F11   ( SOC, SOC, Op_RegF,  11, f11->as_VMReg()         );
@@ -197,26 +197,26 @@ reg_def F16   ( SOC, SOC, Op_RegF,  16, f16->as_VMReg()         );
 reg_def F16_H ( SOC, SOC, Op_RegF,  16, f16->as_VMReg()->next() );
 reg_def F17   ( SOC, SOC, Op_RegF,  17, f17->as_VMReg()         );
 reg_def F17_H ( SOC, SOC, Op_RegF,  17, f17->as_VMReg()->next() );
-reg_def F18   ( SOC, SOC, Op_RegF,  18, f18->as_VMReg()         );
-reg_def F18_H ( SOC, SOC, Op_RegF,  18, f18->as_VMReg()->next() );
-reg_def F19   ( SOC, SOC, Op_RegF,  19, f19->as_VMReg()         );
-reg_def F19_H ( SOC, SOC, Op_RegF,  19, f19->as_VMReg()->next() );
-reg_def F20   ( SOC, SOC, Op_RegF,  20, f20->as_VMReg()         );
-reg_def F20_H ( SOC, SOC, Op_RegF,  20, f20->as_VMReg()->next() );
-reg_def F21   ( SOC, SOC, Op_RegF,  21, f21->as_VMReg()         );
-reg_def F21_H ( SOC, SOC, Op_RegF,  21, f21->as_VMReg()->next() );
-reg_def F22   ( SOC, SOC, Op_RegF,  22, f22->as_VMReg()         );
-reg_def F22_H ( SOC, SOC, Op_RegF,  22, f22->as_VMReg()->next() );
-reg_def F23   ( SOC, SOC, Op_RegF,  23, f23->as_VMReg()         );
-reg_def F23_H ( SOC, SOC, Op_RegF,  23, f23->as_VMReg()->next() );
-reg_def F24   ( SOC, SOC, Op_RegF,  24, f24->as_VMReg()         );
-reg_def F24_H ( SOC, SOC, Op_RegF,  24, f24->as_VMReg()->next() );
-reg_def F25   ( SOC, SOC, Op_RegF,  25, f25->as_VMReg()         );
-reg_def F25_H ( SOC, SOC, Op_RegF,  25, f25->as_VMReg()->next() );
-reg_def F26   ( SOC, SOC, Op_RegF,  26, f26->as_VMReg()         );
-reg_def F26_H ( SOC, SOC, Op_RegF,  26, f26->as_VMReg()->next() );
-reg_def F27   ( SOC, SOC, Op_RegF,  27, f27->as_VMReg()         );
-reg_def F27_H ( SOC, SOC, Op_RegF,  27, f27->as_VMReg()->next() );
+reg_def F18   ( SOC, SOE, Op_RegF,  18, f18->as_VMReg()         );
+reg_def F18_H ( SOC, SOE, Op_RegF,  18, f18->as_VMReg()->next() );
+reg_def F19   ( SOC, SOE, Op_RegF,  19, f19->as_VMReg()         );
+reg_def F19_H ( SOC, SOE, Op_RegF,  19, f19->as_VMReg()->next() );
+reg_def F20   ( SOC, SOE, Op_RegF,  20, f20->as_VMReg()         );
+reg_def F20_H ( SOC, SOE, Op_RegF,  20, f20->as_VMReg()->next() );
+reg_def F21   ( SOC, SOE, Op_RegF,  21, f21->as_VMReg()         );
+reg_def F21_H ( SOC, SOE, Op_RegF,  21, f21->as_VMReg()->next() );
+reg_def F22   ( SOC, SOE, Op_RegF,  22, f22->as_VMReg()         );
+reg_def F22_H ( SOC, SOE, Op_RegF,  22, f22->as_VMReg()->next() );
+reg_def F23   ( SOC, SOE, Op_RegF,  23, f23->as_VMReg()         );
+reg_def F23_H ( SOC, SOE, Op_RegF,  23, f23->as_VMReg()->next() );
+reg_def F24   ( SOC, SOE, Op_RegF,  24, f24->as_VMReg()         );
+reg_def F24_H ( SOC, SOE, Op_RegF,  24, f24->as_VMReg()->next() );
+reg_def F25   ( SOC, SOE, Op_RegF,  25, f25->as_VMReg()         );
+reg_def F25_H ( SOC, SOE, Op_RegF,  25, f25->as_VMReg()->next() );
+reg_def F26   ( SOC, SOE, Op_RegF,  26, f26->as_VMReg()         );
+reg_def F26_H ( SOC, SOE, Op_RegF,  26, f26->as_VMReg()->next() );
+reg_def F27   ( SOC, SOE, Op_RegF,  27, f27->as_VMReg()         );
+reg_def F27_H ( SOC, SOE, Op_RegF,  27, f27->as_VMReg()->next() );
 reg_def F28   ( SOC, SOC, Op_RegF,  28, f28->as_VMReg()         );
 reg_def F28_H ( SOC, SOC, Op_RegF,  28, f28->as_VMReg()->next() );
 reg_def F29   ( SOC, SOC, Op_RegF,  29, f29->as_VMReg()         );


### PR DESCRIPTION
There are unnecessary float register spills before leaf calls and it seems that callee-saved float registers' definitions should be SOE so the register allocator may firstly use these SOE registers as allocation candidates to prevent spills before leaf calls. I have looked through F8-F9, F18-F27 usages and found they are not used in any stub so it could be safe. Tested all cases. [The original patch](https://github.com/riscv-collab/riscv-openjdk/pull/13)

This fix is nearly the same as [JDK-8253048](https://bugs.openjdk.java.net/browse/JDK-8253048)'s [PR](https://github.com/openjdk/jdk/pull/129) on the aarch64 platform and receives an identical result.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278034](https://bugs.openjdk.java.net/browse/JDK-8278034): riscv: Fix callee-saved float register definitions: should be SOE


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/20.diff">https://git.openjdk.java.net/riscv-port/pull/20.diff</a>

</details>
