### PR TITLE
8278192: riscv: remove unnecessary instruct of DecodeNKlass in C2

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2199,17 +2199,16 @@ void MacroAssembler::cmpxchgptr(Register oldv, Register newv, Register addr, Reg
   // addr identifies memory word to compare against/update
   Label retry_load, nope;
   bind(retry_load);
-  // flush and load exclusive from the memory location
-  // and fail if it is not what we expect
+  // Load reserved from the memory location
   lr_d(tmp, addr, Assembler::aqrl);
+  // Fail and exit if it is not what we expect
   bne(tmp, oldv, nope);
-  // if we store+flush with no intervening write tmp wil be zero
+  // If the store conditional succeeds, tmp will be zero
   sc_d(tmp, newv, addr, Assembler::rl);
   beqz(tmp, succeed);
-  // retry so we only ever return after a load fails to compare
-  // ensures we don't return a stale value after a failed write.
+  // Retry only when the store conditional failed
   j(retry_load);
-  // if the memory word differs we return it in oldv and signal a fail
+
   bind(nope);
   membar(AnyAny);
   mv(oldv, tmp);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -2473,17 +2473,6 @@ ATOMIC_XCHGU(xchgalwu, xchgalw)
 
 #undef ATOMIC_XCHGU
 
-void MacroAssembler::atomic_incw(Register counter_addr, Register tmp) {
-  Label retry_load;
-  bind(retry_load);
-  // flush and load exclusive from the memory location
-  lr_w(tmp, counter_addr);
-  addw(tmp, tmp, 1);
-  // if we store+flush with no intervening write tmp wil be zero
-  sc_w(tmp, tmp, counter_addr);
-  bnez(tmp, retry_load);
-}
-
 void MacroAssembler::far_jump(Address entry, CodeBuffer *cbuf, Register tmp) {
   assert(ReservedCodeCacheSize < 4*G, "branch out of range");
   assert(CodeCache::find_blob(entry.target()) != NULL,

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -597,13 +597,6 @@ class MacroAssembler: public Assembler {
     return ReservedCodeCacheSize > branch_range;
   }
 
-  //atomic
-  void atomic_incw(Register counter_addr, Register tmp1);
-  void atomic_incw(Address counter_addr, Register tmp1, Register tmp2) {
-    la(tmp1, counter_addr);
-    atomic_incw(tmp1, tmp2);
-  }
-
   // Jumps that can reach anywhere in the code cache.
   // Trashes tmp.
   void far_call(Address entry, CodeBuffer *cbuf = NULL, Register tmp = t0);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -68,8 +68,8 @@ register %{
 //
 // follow the C1 compiler in making registers
 //
-//   x7, x9-x17, x28-x31 volatile (caller save)
-//   x0-x4, x8, x27 system (no save, no allocate)
+//   x7, x9-x17, x27-x31 volatile (caller save)
+//   x0-x4, x8, x23 system (no save, no allocate)
 //   x5-x6 non-allocatable (so we can use them as temporary regs)
 
 //
@@ -82,8 +82,8 @@ register %{
 
 reg_def R0      ( NS,  NS,  Op_RegI, 0,  x0->as_VMReg()         ); // zr
 reg_def R0_H    ( NS,  NS,  Op_RegI, 0,  x0->as_VMReg()->next() );
-reg_def R1      ( SOC, SOC, Op_RegI, 1,  x1->as_VMReg()         ); // ra
-reg_def R1_H    ( SOC, SOC, Op_RegI, 1,  x1->as_VMReg()->next() );
+reg_def R1      ( NS,  SOC, Op_RegI, 1,  x1->as_VMReg()         ); // ra
+reg_def R1_H    ( NS,  SOC, Op_RegI, 1,  x1->as_VMReg()->next() );
 reg_def R2      ( NS,  SOE, Op_RegI, 2,  x2->as_VMReg()         ); // sp
 reg_def R2_H    ( NS,  SOE, Op_RegI, 2,  x2->as_VMReg()->next() );
 reg_def R3      ( NS,  NS,  Op_RegI, 3,  x3->as_VMReg()         ); // gp
@@ -1018,9 +1018,6 @@ bool needs_acquiring_load_reserved(const Node *load);
 
 // predicate controlling addressing modes
 bool size_fits_all_mem_uses(AddPNode* addp, int shift);
-
-// predicate using the temp register for decoding klass
-bool maybe_use_tmp_register_decoding_klass();
 %}
 
 source %{
@@ -1140,12 +1137,6 @@ bool needs_acquiring_load_reserved(const Node *n)
   }
   // so we can just return true here
   return true;
-}
-
-bool maybe_use_tmp_register_decoding_klass() {
-  return !UseCompressedOops &&
-         CompressedKlassPointers::base() != NULL &&
-         CompressedKlassPointers::shift() != 0;
 }
 #define __ _masm.
 
@@ -1276,9 +1267,9 @@ void MachPrologNode::format(PhaseRegAlloc *ra_, outputStream *st) const {
     st->print("# stack bang size=%d\n\t", framesize);
   }
 
-  st->print("sd  fp, [sp, #%d]", - 2 * wordSize);
-  st->print("sd  ra, [sp, #%d]", - wordSize);
-  if (PreserveFramePointer) { st->print("\n\tsub  fp, sp, #%d", 2 * wordSize); }
+  st->print("sd  fp, [sp, #%d]\n\t", - 2 * wordSize);
+  st->print("sd  ra, [sp, #%d]\n\t", - wordSize);
+  if (PreserveFramePointer) { st->print("sub  fp, sp, #%d\n\t", 2 * wordSize); }
   st->print("sub sp, sp, #%d\n\t", framesize);
 
   if (C->stub_function() == NULL && BarrierSet::barrier_set()->barrier_set_nmethod() != NULL) {
@@ -1681,14 +1672,16 @@ void MachUEPNode::format(PhaseRegAlloc* ra_, outputStream* st) const
   assert_cond(st != NULL);
   st->print_cr("# MachUEPNode");
   if (UseCompressedClassPointers) {
-    st->print_cr("\tlw t0, [j_rarg0, oopDesc::klass_offset_in_bytes()]\t# compressed klass");
+    st->print_cr("\tlwu t0, [j_rarg0, oopDesc::klass_offset_in_bytes()]\t# compressed klass");
     if (CompressedKlassPointers::shift() != 0) {
       st->print_cr("\tdecode_klass_not_null t0, t0");
     }
   } else {
-   st->print_cr("\tld t0, [j_rarg0, oopDesc::klass_offset_in_bytes()]\t# compressed klass");
+    st->print_cr("\tld t0, [j_rarg0, oopDesc::klass_offset_in_bytes()]\t# compressed klass");
   }
-  st->print_cr("\tbne x10, t0, SharedRuntime::_ic_miss_stub\t # Inline cache check");
+  st->print_cr("\tbeq t0, t1, ic_hit");
+  st->print_cr("\tj, SharedRuntime::_ic_miss_stub\t # Inline cache check");
+  st->print_cr("\tic_hit:");
 }
 #endif
 
@@ -8106,10 +8099,10 @@ instruct encodeKlass_not_null(iRegNNoSp dst, iRegP src) %{
    ins_pipe(ialu_reg);
 %}
 
-instruct decodeKlass_not_null(iRegPNoSp dst, iRegN src) %{
-  predicate(!maybe_use_tmp_register_decoding_klass());
-
+instruct decodeKlass_not_null(iRegPNoSp dst, iRegN src, iRegPNoSp tmp) %{
   match(Set dst (DecodeNKlass src));
+
+  effect(TEMP tmp);
 
   ins_cost(ALU_COST);
   format %{ "decode_klass_not_null  $dst, $src\t#@decodeKlass_not_null" %}
@@ -8117,26 +8110,7 @@ instruct decodeKlass_not_null(iRegPNoSp dst, iRegN src) %{
   ins_encode %{
     Register src_reg = as_Register($src$$reg);
     Register dst_reg = as_Register($dst$$reg);
-    __ decode_klass_not_null(dst_reg, src_reg, UseCompressedOops ? xheapbase : t0);
-  %}
-
-   ins_pipe(ialu_reg);
-%}
-
-instruct decodeKlass_not_null_with_tmp(iRegPNoSp dst, iRegN src, rFlagsReg cr) %{
-  predicate(maybe_use_tmp_register_decoding_klass());
-
-  match(Set dst (DecodeNKlass src));
-
-  effect(TEMP cr);
-
-  ins_cost(ALU_COST);
-  format %{ "decode_klass_not_null  $dst, $src\t#@decodeKlass_not_null" %}
-
-  ins_encode %{
-    Register src_reg = as_Register($src$$reg);
-    Register dst_reg = as_Register($dst$$reg);
-    Register tmp_reg = as_Register($cr$$reg);
+    Register tmp_reg = as_Register($tmp$$reg);
     __ decode_klass_not_null(dst_reg, src_reg, tmp_reg);
   %}
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -24,7 +24,7 @@
 //
 //
 
-// Riscv64 VEC Architecture Description File
+// RISCV Vector Extension Architecture Description File
 
 opclass vmemA(indirect);
 


### PR DESCRIPTION
There are two instructs for DecodeNKlass in C2, and the difference is only that which temporary register operand is used by them, xheapbase, t0 or t1. It's too complicated and the effect is almost invisible. So we just simplify the pattern by using a temporary register from the register allocation.
Hotspot and jdk tier1 passed on the unmatched board. And all jtreg tests were tested on qemu without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278192](https://bugs.openjdk.java.net/browse/JDK-8278192): riscv: remove unnecessary instruct of DecodeNKlass in C2


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/22.diff">https://git.openjdk.java.net/riscv-port/pull/22.diff</a>

</details>
