### PR TITLE
8276832: riscv: typo in LIR_Assembler::check_no_conflict

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1661,8 +1661,7 @@ void LIR_Assembler::check_no_conflict(ciKlass* exact_klass, intptr_t current_kla
   }
 #endif
     // first time here. Set profile type.
-    // TODO: Fix this typo. See JDK-8267625.
-    __ ld(tmp, mdo_addr);
+    __ sd(tmp, mdo_addr);
   } else {
     assert(ciTypeEntries::valid_ciklass(current_klass) != NULL &&
            ciTypeEntries::valid_ciklass(current_klass) != exact_klass, "inconsistent");


### PR DESCRIPTION
This is similar to: 8267625: AARCH64: typo in LIR_Assembler::emit_profile_type.

Difference is that LIR_Assembler::emit_profile_type is refactored and now the typo is in LIR_Assembler::check_no_conflict.

And LIR_Assembler::check_no_conflict is only called by LIR_Assembler::emit_profile_type for now.

The result  of testcase on QEMU（https://bugs.openjdk.java.net/secure/attachment/95368/Test.java）：
Before：
```
static Test::test(LTest$A;I)I
  interpreter_invocation_count:        5376
  invocation_counter:                  5376
  backedge_counter:                       0
  decompile_count:                        0
  mdo size: 416 bytes

  ParametersTypeData  0: stack(0) none
```
After "ld" -> "sd":
```
static Test::test(LTest$A;I)I
  interpreter_invocation_count:        5376
  invocation_counter:                  5376
  backedge_counter:                       0
  decompile_count:                        0
  mdo size: 416 bytes

  ParametersTypeData  0: stack(0) 'Test$A'
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8276832](https://bugs.openjdk.java.net/browse/JDK-8276832): riscv: typo in LIR_Assembler::check_no_conflict


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/23/head:pull/23` \
`$ git checkout pull/23`

Update a local copy of the PR: \
`$ git checkout pull/23` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/23/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 23`

View PR using the GUI difftool: \
`$ git pr show -t 23`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/23.diff">https://git.openjdk.java.net/riscv-port/pull/23.diff</a>

</details>
