### PR TITLE
8278322: riscv: Support RVC: compressed instructions

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv_cext.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv_cext.hpp
@@ -1,0 +1,865 @@
+/*
+ * Copyright (c) 1997, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2021, Alibaba Group Holding Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV_ASSEMBLER_RISCV_CEXT_HPP
+#define CPU_RISCV_ASSEMBLER_RISCV_CEXT_HPP
+
+  // C-Ext: If an instruction is compressible, then
+  //   we will implicitly emit a 16-bit compressed instruction instead of the 32-bit
+  //   instruction in Assembler. All below logic follows Chapter -
+  //   "C" Standard Extension for Compressed Instructions, Version 2.0.
+  //   We can get code size reduction and performance improvement with this extension,
+  //   considering the reduction of instruction size and the code density increment.
+
+  // Note:
+  //   1. When UseRVC is enabled, some of normal instructions will be implicitly
+  //      changed to its 16-bit version.
+  //   2. C-Ext's instructions in Assembler always end with '_c' suffix, as 'li_c',
+  //      but most of time we have no need to explicitly use these instructions.
+  //      (Although spec says 'c.li', we use 'li_c' to unify related names - see below.
+  //   3. In some cases, we need to force using one instruction's uncompressed version,
+  //      for instance code being patched should remain its general and longest version
+  //      to cover all possible cases, or code requiring a fixed length.
+  //      So we introduce '_nc' suffix (short for: not compressible) to force an instruction
+  //      to remain its normal 4-byte version.
+  //     An example:
+  //      j() (32-bit) could become j_c() (16-bit) with -XX:+UseRVC if compressible. We could
+  //      use j_nc() to force it to remain its normal 4-byte version.
+  //   4. Using -XX:PrintAssemblyOptions=no-aliases could print C-Ext instructions instead of
+  //      normal ones.
+  //
+
+  // C-Ext: incompressible version
+  void j_nc(const address &dest, Register temp = t0);
+  void j_nc(const Address &adr, Register temp = t0) ;
+  void j_nc(Label &l, Register temp = t0);
+  void jal_nc(Label &l, Register temp = t0);
+  void jal_nc(const address &dest, Register temp = t0);
+  void jal_nc(const Address &adr, Register temp = t0);
+  void jr_nc(Register Rs);
+  void jalr_nc(Register Rs);
+  void call_nc(const address &dest, Register temp = t0);
+  void tail_nc(const address &dest, Register temp = t0);
+
+  // C-Ext: extract a 16-bit instruction.
+  static inline uint16_t extract_c(uint16_t val, unsigned msb, unsigned lsb) {
+    assert_cond(msb >= lsb && msb <= 15);
+    unsigned nbits = msb - lsb + 1;
+    uint16_t mask = (1U << nbits) - 1;
+    uint16_t result = val >> lsb;
+    result &= mask;
+    return result;
+  }
+
+  static inline int16_t sextract_c(uint16_t val, unsigned msb, unsigned lsb) {
+    assert_cond(msb >= lsb && msb <= 15);
+    int16_t result = val << (15 - msb);
+    result >>= (15 - msb + lsb);
+    return result;
+  }
+
+  // C-Ext: patch a 16-bit instruction.
+  static void patch_c(address a, unsigned msb, unsigned lsb, uint16_t val) {
+    assert_cond(a != NULL);
+    assert_cond(msb >= lsb && msb <= 15);
+    unsigned nbits = msb - lsb + 1;
+    guarantee(val < (1U << nbits), "Field too big for insn");
+    uint16_t mask = (1U << nbits) - 1;
+    val <<= lsb;
+    mask <<= lsb;
+    uint16_t target = *(uint16_t *)a;
+    target &= ~mask;
+    target |= val;
+    *(uint16_t *)a = target;
+  }
+
+  static void patch_c(address a, unsigned bit, uint16_t val) {
+    patch_c(a, bit, bit, val);
+  }
+
+  // C-Ext: patch a 16-bit instruction with a general purpose register ranging [0, 31] (5 bits)
+  static void patch_reg_c(address a, unsigned lsb, Register reg) {
+    patch_c(a, lsb + 4, lsb, reg->encoding_nocheck());
+  }
+
+  // C-Ext: patch a 16-bit instruction with a general purpose register ranging [8, 15] (3 bits)
+  static void patch_compressed_reg_c(address a, unsigned lsb, Register reg) {
+    patch_c(a, lsb + 2, lsb, reg->compressed_encoding_nocheck());
+  }
+
+  // C-Ext: patch a 16-bit instruction with a float register ranging [0, 31] (5 bits)
+  static void patch_reg_c(address a, unsigned lsb, FloatRegister reg) {
+    patch_c(a, lsb + 4, lsb, reg->encoding_nocheck());
+  }
+
+  // C-Ext: patch a 16-bit instruction with a float register ranging [8, 15] (3 bits)
+  static void patch_compressed_reg_c(address a, unsigned lsb, FloatRegister reg) {
+    patch_c(a, lsb + 2, lsb, reg->compressed_encoding_nocheck());
+  }
+
+public:
+
+// C-Ext: Compressed Instructions
+
+// --------------  C-Ext Instruction Definitions  --------------
+
+  void nop_c() {
+    addi_c(x0, 0);
+  }
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(Register Rd_Rs1, int32_t imm) {                                                  \
+    assert_cond(is_imm_in_range(imm, 6, 0));                                                 \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 6, 2, (imm & right_n_bits(5)));                                  \
+    patch_reg_c((address)&insn, 7, Rd_Rs1);                                                  \
+    patch_c((address)&insn, 12, 12, (imm & nth_bit(5)) >> 5);                                \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(addi_c,   0b000, 0b01);
+  INSN(addiw_c,  0b001, 0b01);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(int32_t imm) {                                                                   \
+    assert_cond(is_imm_in_range(imm, 10, 0));                                                \
+    assert_cond((imm & 0b1111) == 0);                                                        \
+    assert_cond(imm != 0);                                                                   \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 2, 2, (imm & nth_bit(5)) >> 5);                                  \
+    patch_c((address)&insn, 4, 3, (imm & right_n_bits(9)) >> 7);                             \
+    patch_c((address)&insn, 5, 5, (imm & nth_bit(6)) >> 6);                                  \
+    patch_c((address)&insn, 6, 6, (imm & nth_bit(4)) >> 4);                                  \
+    patch_reg_c((address)&insn, 7, sp);                                                      \
+    patch_c((address)&insn, 12, 12, (imm & nth_bit(9)) >> 9);                                \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(addi16sp_c, 0b011, 0b01);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(Register Rd, uint32_t uimm) {                                                    \
+    assert_cond(is_unsigned_imm_in_range(uimm, 10, 0));                                      \
+    assert_cond((uimm & 0b11) == 0);                                                         \
+    assert_cond(uimm != 0);                                                                  \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_compressed_reg_c((address)&insn, 2, Rd);                                           \
+    patch_c((address)&insn, 5, 5, (uimm & nth_bit(3)) >> 3);                                 \
+    patch_c((address)&insn, 6, 6, (uimm & nth_bit(2)) >> 2);                                 \
+    patch_c((address)&insn, 10, 7, (uimm & right_n_bits(10)) >> 6);                          \
+    patch_c((address)&insn, 12, 11, (uimm & right_n_bits(6)) >> 4);                          \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(addi4spn_c, 0b000, 0b00);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(Register Rd_Rs1, uint32_t shamt) {                                               \
+    assert_cond(is_unsigned_imm_in_range(shamt, 6, 0));                                      \
+    assert_cond(shamt != 0);                                                                 \
+    assert_cond(Rd_Rs1 != x0);                                                               \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 6, 2, (shamt & right_n_bits(5)));                                \
+    patch_reg_c((address)&insn, 7, Rd_Rs1);                                                  \
+    patch_c((address)&insn, 12, 12, (shamt & nth_bit(5)) >> 5);                              \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(slli_c, 0b000, 0b10);
+
+#undef INSN
+
+#define INSN(NAME, funct3, funct2, op)                                                       \
+  void NAME(Register Rd_Rs1, uint32_t shamt) {                                               \
+    assert_cond(is_unsigned_imm_in_range(shamt, 6, 0));                                      \
+    assert_cond(shamt != 0);                                                                 \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 6, 2, (shamt & right_n_bits(5)));                                \
+    patch_compressed_reg_c((address)&insn, 7, Rd_Rs1);                                       \
+    patch_c((address)&insn, 11, 10, funct2);                                                 \
+    patch_c((address)&insn, 12, 12, (shamt & nth_bit(5)) >> 5);                              \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(srli_c, 0b100, 0b00, 0b01);
+  INSN(srai_c, 0b100, 0b01, 0b01);
+
+#undef INSN
+
+#define INSN(NAME, funct3, funct2, op)                                                       \
+  void NAME(Register Rd_Rs1, int32_t imm) {                                                  \
+    assert_cond(is_imm_in_range(imm, 6, 0));                                                 \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 6, 2, (imm & right_n_bits(5)));                                  \
+    patch_compressed_reg_c((address)&insn, 7, Rd_Rs1);                                       \
+    patch_c((address)&insn, 11, 10, funct2);                                                 \
+    patch_c((address)&insn, 12, 12, (imm & nth_bit(5)) >> 5);                                \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(andi_c, 0b100, 0b10, 0b01);
+
+#undef INSN
+
+#define INSN(NAME, funct6, funct2, op)                                                       \
+  void NAME(Register Rd_Rs1, Register Rs2) {                                                 \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_compressed_reg_c((address)&insn, 2, Rs2);                                          \
+    patch_c((address)&insn, 6, 5, funct2);                                                   \
+    patch_compressed_reg_c((address)&insn, 7, Rd_Rs1);                                       \
+    patch_c((address)&insn, 15, 10, funct6);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(sub_c,  0b100011, 0b00, 0b01);
+  INSN(xor_c,  0b100011, 0b01, 0b01);
+  INSN(or_c,   0b100011, 0b10, 0b01);
+  INSN(and_c,  0b100011, 0b11, 0b01);
+  INSN(subw_c, 0b100111, 0b00, 0b01);
+  INSN(addw_c, 0b100111, 0b01, 0b01);
+
+#undef INSN
+
+#define INSN(NAME, funct4, op)                                                               \
+  void NAME(Register Rd_Rs1, Register Rs2) {                                                 \
+    assert_cond(Rd_Rs1 != x0);                                                               \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_reg_c((address)&insn, 2, Rs2);                                                     \
+    patch_reg_c((address)&insn, 7, Rd_Rs1);                                                  \
+    patch_c((address)&insn, 15, 12, funct4);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(mv_c,  0b1000, 0b10);
+  INSN(add_c, 0b1001, 0b10);
+
+#undef INSN
+
+#define INSN(NAME, funct4, op)                                                               \
+  void NAME(Register Rs1) {                                                                  \
+    assert_cond(Rs1 != x0);                                                                  \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_reg_c((address)&insn, 2, x0);                                                      \
+    patch_reg_c((address)&insn, 7, Rs1);                                                     \
+    patch_c((address)&insn, 15, 12, funct4);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(jr_c,   0b1000, 0b10);
+  INSN(jalr_c, 0b1001, 0b10);
+
+#undef INSN
+
+  typedef void (Assembler::* j_c_insn)(address dest);
+  typedef void (Assembler::* compare_and_branch_c_insn)(Register Rs1, address dest);
+
+  void wrap_label(Label &L, j_c_insn insn);
+  void wrap_label(Label &L, Register r, compare_and_branch_c_insn insn);
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(int32_t offset) {                                                                \
+    assert_cond(is_imm_in_range(offset, 11, 1));                                             \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 2, 2, (offset & nth_bit(5)) >> 5);                               \
+    patch_c((address)&insn, 5, 3, (offset & right_n_bits(4)) >> 1);                          \
+    patch_c((address)&insn, 6, 6, (offset & nth_bit(7)) >> 7);                               \
+    patch_c((address)&insn, 7, 7, (offset & nth_bit(6)) >> 6);                               \
+    patch_c((address)&insn, 8, 8, (offset & nth_bit(10)) >> 10);                             \
+    patch_c((address)&insn, 10, 9, (offset & right_n_bits(10)) >> 8);                        \
+    patch_c((address)&insn, 11, 11, (offset & nth_bit(4)) >> 4);                             \
+    patch_c((address)&insn, 12, 12, (offset & nth_bit(11)) >> 11);                           \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }                                                                                          \
+  void NAME(address dest) {                                                                  \
+    assert_cond(dest != NULL);                                                               \
+    int64_t distance = dest - pc();                                                          \
+    assert_cond(is_imm_in_range(distance, 11, 1));                                           \
+    j_c(distance);                                                                           \
+  }                                                                                          \
+  void NAME(Label &L) {                                                                      \
+    wrap_label(L, &Assembler::NAME);                                                         \
+  }
+
+  INSN(j_c, 0b101, 0b01);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(Register Rs1, int32_t imm) {                                                     \
+    assert_cond(is_imm_in_range(imm, 8, 1));                                                 \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 2, 2, (imm & nth_bit(5)) >> 5);                                  \
+    patch_c((address)&insn, 4, 3, (imm & right_n_bits(3)) >> 1);                             \
+    patch_c((address)&insn, 6, 5, (imm & right_n_bits(8)) >> 6);                             \
+    patch_compressed_reg_c((address)&insn, 7, Rs1);                                          \
+    patch_c((address)&insn, 11, 10, (imm & right_n_bits(5)) >> 3);                           \
+    patch_c((address)&insn, 12, 12, (imm & nth_bit(8)) >> 8);                                \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }                                                                                          \
+  void NAME(Register Rs1, address dest) {                                                    \
+    assert_cond(dest != NULL);                                                               \
+    int64_t distance = dest - pc();                                                          \
+    assert_cond(is_imm_in_range(distance, 8, 1));                                            \
+    NAME(Rs1, distance);                                                                     \
+  }                                                                                          \
+  void NAME(Register Rs1, Label &L) {                                                        \
+    wrap_label(L, Rs1, &Assembler::NAME);                                                    \
+  }
+
+  INSN(beqz_c, 0b110, 0b01);
+  INSN(bnez_c, 0b111, 0b01);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(Register Rd, int32_t imm) {                                                      \
+    assert_cond(is_imm_in_range(imm, 18, 0));                                                \
+    assert_cond((imm & 0xfff) == 0);                                                         \
+    assert_cond(imm != 0);                                                                   \
+    assert_cond(Rd != x0 && Rd != x2);                                                       \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 6, 2, (imm & right_n_bits(17)) >> 12);                           \
+    patch_reg_c((address)&insn, 7, Rd);                                                      \
+    patch_c((address)&insn, 12, 12, (imm & nth_bit(17)) >> 17);                              \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(lui_c, 0b011, 0b01);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(Register Rd, int32_t imm) {                                                      \
+    assert_cond(is_imm_in_range(imm, 6, 0));                                                 \
+    assert_cond(Rd != x0);                                                                   \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 6, 2, (imm & right_n_bits(5)));                                  \
+    patch_reg_c((address)&insn, 7, Rd);                                                      \
+    patch_c((address)&insn, 12, 12, (imm & right_n_bits(6)) >> 5);                           \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(li_c, 0b010, 0b01);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op, REGISTER_TYPE, CHECK)                                         \
+  void NAME(REGISTER_TYPE Rd, uint32_t uimm) {                                               \
+    assert_cond(is_unsigned_imm_in_range(uimm, 9, 0));                                       \
+    assert_cond((uimm & 0b111) == 0);                                                        \
+    IF(CHECK, assert_cond(Rd != x0);)                                                        \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 4, 2, (uimm & right_n_bits(9)) >> 6);                            \
+    patch_c((address)&insn, 6, 5, (uimm & right_n_bits(5)) >> 3);                            \
+    patch_reg_c((address)&insn, 7, Rd);                                                      \
+    patch_c((address)&insn, 12, 12, (uimm & nth_bit(5)) >> 5);                               \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+#define IF(BOOL, ...)       IF_##BOOL(__VA_ARGS__)
+#define IF_true(code)       code
+#define IF_false(code)
+
+  INSN(ldsp_c,  0b011, 0b10, Register,      true);
+  INSN(fldsp_c, 0b001, 0b10, FloatRegister, false);
+
+#undef IF_false
+#undef IF_true
+#undef IF
+#undef INSN
+
+#define INSN(NAME, funct3, op, REGISTER_TYPE)                                                \
+  void NAME(REGISTER_TYPE Rd_Rs2, Register Rs1, uint32_t uimm) {                             \
+    assert_cond(is_unsigned_imm_in_range(uimm, 8, 0));                                       \
+    assert_cond((uimm & 0b111) == 0);                                                        \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_compressed_reg_c((address)&insn, 2, Rd_Rs2);                                       \
+    patch_c((address)&insn, 6, 5, (uimm & right_n_bits(8)) >> 6);                            \
+    patch_compressed_reg_c((address)&insn, 7, Rs1);                                          \
+    patch_c((address)&insn, 12, 10, (uimm & right_n_bits(6)) >> 3);                          \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(ld_c,  0b011, 0b00, Register);
+  INSN(sd_c,  0b111, 0b00, Register);
+  INSN(fld_c, 0b001, 0b00, FloatRegister);
+  INSN(fsd_c, 0b101, 0b00, FloatRegister);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op, REGISTER_TYPE)                                                \
+  void NAME(REGISTER_TYPE Rs2, uint32_t uimm) {                                              \
+    assert_cond(is_unsigned_imm_in_range(uimm, 9, 0));                                       \
+    assert_cond((uimm & 0b111) == 0);                                                        \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_reg_c((address)&insn, 2, Rs2);                                                     \
+    patch_c((address)&insn, 9, 7, (uimm & right_n_bits(9)) >> 6);                            \
+    patch_c((address)&insn, 12, 10, (uimm & right_n_bits(6)) >> 3);                          \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(sdsp_c,  0b111, 0b10, Register);
+  INSN(fsdsp_c, 0b101, 0b10, FloatRegister);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(Register Rs2, uint32_t uimm) {                                                   \
+    assert_cond(is_unsigned_imm_in_range(uimm, 8, 0));                                       \
+    assert_cond((uimm & 0b11) == 0);                                                         \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_reg_c((address)&insn, 2, Rs2);                                                     \
+    patch_c((address)&insn, 8, 7, (uimm & right_n_bits(8)) >> 6);                            \
+    patch_c((address)&insn, 12, 9, (uimm & right_n_bits(6)) >> 2);                           \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(swsp_c, 0b110, 0b10);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(Register Rd, uint32_t uimm) {                                                    \
+    assert_cond(is_unsigned_imm_in_range(uimm, 8, 0));                                       \
+    assert_cond((uimm & 0b11) == 0);                                                         \
+    assert_cond(Rd != x0);                                                                   \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 3, 2, (uimm & right_n_bits(8)) >> 6);                            \
+    patch_c((address)&insn, 6, 4, (uimm & right_n_bits(5)) >> 2);                            \
+    patch_reg_c((address)&insn, 7, Rd);                                                      \
+    patch_c((address)&insn, 12, 12, (uimm & nth_bit(5)) >> 5);                               \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(lwsp_c, 0b010, 0b10);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME(Register Rd_Rs2, Register Rs1, uint32_t uimm) {                                  \
+    assert_cond(is_unsigned_imm_in_range(uimm, 7, 0));                                       \
+    assert_cond((uimm & 0b11) == 0);                                                         \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_compressed_reg_c((address)&insn, 2, Rd_Rs2);                                       \
+    patch_c((address)&insn, 5, 5, (uimm & nth_bit(6)) >> 6);                                 \
+    patch_c((address)&insn, 6, 6, (uimm & nth_bit(2)) >> 2);                                 \
+    patch_compressed_reg_c((address)&insn, 7, Rs1);                                          \
+    patch_c((address)&insn, 12, 10, (uimm & right_n_bits(6)) >> 3);                          \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(lw_c, 0b010, 0b00);
+  INSN(sw_c, 0b110, 0b00);
+
+#undef INSN
+
+#define INSN(NAME, funct3, op)                                                               \
+  void NAME() {                                                                              \
+    uint16_t insn = 0;                                                                       \
+    patch_c((address)&insn, 1, 0, op);                                                       \
+    patch_c((address)&insn, 11, 2, 0x0);                                                     \
+    patch_c((address)&insn, 12, 12, 0b1);                                                    \
+    patch_c((address)&insn, 15, 13, funct3);                                                 \
+    emit_int16(insn);                                                                        \
+  }
+
+  INSN(ebreak_c, 0b100, 0b10);
+
+#undef INSN
+
+// --------------  C-Ext Transformation Macros  --------------
+
+// a pivotal dispatcher for C-Ext
+#define EMIT_MAY_COMPRESS(COMPRESSIBLE, NAME, ...)    EMIT_MAY_COMPRESS_##COMPRESSIBLE(NAME, __VA_ARGS__)
+#define EMIT_MAY_COMPRESS_true(NAME, ...)             EMIT_MAY_COMPRESS_##NAME(__VA_ARGS__)
+#define EMIT_MAY_COMPRESS_false(NAME, ...)
+
+#define IS_COMPRESSIBLE(...)                          if (__VA_ARGS__)
+#define CHECK_CEXT_AND_COMPRESSIBLE(...)              IS_COMPRESSIBLE(UseRVC && __VA_ARGS__)
+#define CHECK_CEXT()                                  if (UseRVC)
+
+// C-Ext transformation macros
+#define EMIT_RVC_cond(PREFIX, COND, EMIT) {                                            \
+    PREFIX                                                                             \
+    CHECK_CEXT_AND_COMPRESSIBLE(COND) {                                                \
+      EMIT;                                                                            \
+      return;                                                                          \
+    }                                                                                  \
+  }
+
+#define EMIT_RVC_cond2(PREFIX, COND1, EMIT1, COND2, EMIT2) {                           \
+    PREFIX                                                                             \
+    CHECK_CEXT() {                                                                     \
+      IS_COMPRESSIBLE(COND1) {                                                         \
+        EMIT1;                                                                         \
+        return;                                                                        \
+      } else IS_COMPRESSIBLE(COND2) {                                                  \
+        EMIT2;                                                                         \
+        return;                                                                        \
+      }                                                                                \
+    }                                                                                  \
+  }
+
+#define EMIT_RVC_cond4(PREFIX, COND1, EMIT1, COND2, EMIT2, COND3, EMIT3, COND4, EMIT4) {  \
+    PREFIX                                                                             \
+    CHECK_CEXT() {                                                                     \
+      IS_COMPRESSIBLE(COND1) {                                                         \
+        EMIT1;                                                                         \
+        return;                                                                        \
+      } else IS_COMPRESSIBLE(COND2) {                                                  \
+        EMIT2;                                                                         \
+        return;                                                                        \
+      } else IS_COMPRESSIBLE(COND3) {                                                  \
+        EMIT3;                                                                         \
+        return;                                                                        \
+      } else IS_COMPRESSIBLE(COND4) {                                                  \
+        EMIT4;                                                                         \
+        return;                                                                        \
+      }                                                                                \
+    }                                                                                  \
+  }
+
+// --------------------------
+// Register instructions
+// --------------------------
+// add -> c.add
+#define EMIT_MAY_COMPRESS_add(Rd, Rs1, Rs2)                                            \
+  EMIT_RVC_cond(                                                                       \
+    Register src = noreg;,                                                             \
+    Rs1 != x0 && Rs2 != x0 && ((src = Rs1, Rs2 == Rd) || (src = Rs2, Rs1 == Rd)),      \
+    add_c(Rd, src)                                                                     \
+  )
+
+// --------------------------
+// sub/subw -> c.sub/c.subw
+#define EMIT_MAY_COMPRESS_sub_helper(NAME_C, Rd, Rs1, Rs2)                             \
+  EMIT_RVC_cond(,                                                                      \
+    Rs1 == Rd && Rd->is_compressed_valid() && Rs2->is_compressed_valid(),              \
+    NAME_C(Rd, Rs2)                                                                    \
+  )
+
+#define EMIT_MAY_COMPRESS_sub(Rd, Rs1, Rs2)                                            \
+  EMIT_MAY_COMPRESS_sub_helper(sub_c, Rd, Rs1, Rs2)
+
+#define EMIT_MAY_COMPRESS_subw(Rd, Rs1, Rs2)                                           \
+  EMIT_MAY_COMPRESS_sub_helper(subw_c, Rd, Rs1, Rs2)
+
+// --------------------------
+// xor/or/and/addw -> c.xor/c.or/c.and/c.addw
+#define EMIT_MAY_COMPRESS_xorr_orr_andr_addw_helper(NAME_C, Rd, Rs1, Rs2)              \
+  EMIT_RVC_cond(                                                                       \
+    Register src = noreg;,                                                             \
+    Rs1->is_compressed_valid() && Rs2->is_compressed_valid() &&                        \
+      ((src = Rs1, Rs2 == Rd) || (src = Rs2, Rs1 == Rd)),                              \
+    NAME_C(Rd, src)                                                                    \
+  )
+
+#define EMIT_MAY_COMPRESS_xorr(Rd, Rs1, Rs2)                                           \
+  EMIT_MAY_COMPRESS_xorr_orr_andr_addw_helper(xor_c, Rd, Rs1, Rs2)
+
+#define EMIT_MAY_COMPRESS_orr(Rd, Rs1, Rs2)                                            \
+  EMIT_MAY_COMPRESS_xorr_orr_andr_addw_helper(or_c, Rd, Rs1, Rs2)
+
+#define EMIT_MAY_COMPRESS_andr(Rd, Rs1, Rs2)                                           \
+  EMIT_MAY_COMPRESS_xorr_orr_andr_addw_helper(and_c, Rd, Rs1, Rs2)
+
+#define EMIT_MAY_COMPRESS_addw(Rd, Rs1, Rs2)                                           \
+  EMIT_MAY_COMPRESS_xorr_orr_andr_addw_helper(addw_c, Rd, Rs1, Rs2)
+
+// --------------------------
+// Load/store register (all modes)
+// --------------------------
+private:
+
+#define FUNC(NAME, funct3, bits)                                                       \
+  bool NAME(Register rs1, Register rd_rs2, int32_t imm12, bool ld) {                   \
+    return rs1 == sp &&                                                                \
+      is_unsigned_imm_in_range(imm12, bits, 0) &&                                      \
+      (intx(imm12) & funct3) == 0x0 &&                                                 \
+      (!ld || rd_rs2 != x0);                                                           \
+  }                                                                                    \
+
+  FUNC(is_ldsdsp_c,  0b111, 9);
+  FUNC(is_lwswsp_c,  0b011, 8);
+#undef FUNC
+
+#define FUNC(NAME, funct3, bits)                                                       \
+  bool NAME(Register rs1, int32_t imm12) {                                             \
+    return rs1 == sp &&                                                                \
+      is_unsigned_imm_in_range(imm12, bits, 0) &&                                      \
+      (intx(imm12) & funct3) == 0x0;                                                   \
+  }                                                                                    \
+
+  FUNC(is_fldsdsp_c, 0b111, 9);
+#undef FUNC
+
+#define FUNC(NAME, REG_TYPE, funct3, bits)                                             \
+  bool NAME(Register rs1, REG_TYPE rd_rs2, int32_t imm12) {                            \
+    return rs1->is_compressed_valid() &&                                               \
+      rd_rs2->is_compressed_valid() &&                                                 \
+      is_unsigned_imm_in_range(imm12, bits, 0) &&                                      \
+      (intx(imm12) & funct3) == 0x0;                                                   \
+  }                                                                                    \
+
+  FUNC(is_ldsd_c,  Register,      0b111, 8);
+  FUNC(is_lwsw_c,  Register,      0b011, 7);
+  FUNC(is_fldsd_c, FloatRegister, 0b111, 8);
+#undef FUNC
+
+public:
+// --------------------------
+// ld -> c.ldsp/c.ld
+#define EMIT_MAY_COMPRESS_ld(Rd, Rs, offset)                                           \
+  EMIT_RVC_cond2(,                                                                     \
+     is_ldsdsp_c(Rs, Rd, offset, true),                                                \
+     ldsp_c(Rd, offset),                                                               \
+     is_ldsd_c(Rs, Rd, offset),                                                        \
+     ld_c(Rd, Rs, offset)                                                              \
+  )
+
+// --------------------------
+// sd -> c.sdsp/c.sd
+#define EMIT_MAY_COMPRESS_sd(Rd, Rs, offset)                                           \
+  EMIT_RVC_cond2(,                                                                     \
+     is_ldsdsp_c(Rs, Rd, offset, false),                                               \
+     sdsp_c(Rd, offset),                                                               \
+     is_ldsd_c(Rs, Rd, offset),                                                        \
+     sd_c(Rd, Rs, offset)                                                              \
+  )
+
+// --------------------------
+// lw -> c.lwsp/c.lw
+#define EMIT_MAY_COMPRESS_lw(Rd, Rs, offset)                                           \
+  EMIT_RVC_cond2(,                                                                     \
+     is_lwswsp_c(Rs, Rd, offset, true),                                                \
+     lwsp_c(Rd, offset),                                                               \
+     is_lwsw_c(Rs, Rd, offset),                                                        \
+     lw_c(Rd, Rs, offset)                                                              \
+  )
+
+// --------------------------
+// sw -> c.swsp/c.sw
+#define EMIT_MAY_COMPRESS_sw(Rd, Rs, offset)                                           \
+  EMIT_RVC_cond2(,                                                                     \
+     is_lwswsp_c(Rs, Rd, offset, false),                                               \
+     swsp_c(Rd, offset),                                                               \
+     is_lwsw_c(Rs, Rd, offset),                                                        \
+     sw_c(Rd, Rs, offset)                                                              \
+  )
+
+// --------------------------
+// fld -> c.fldsp/c.fld
+#define EMIT_MAY_COMPRESS_fld(Rd, Rs, offset)                                          \
+  EMIT_RVC_cond2(,                                                                     \
+     is_fldsdsp_c(Rs, offset),                                                         \
+     fldsp_c(Rd, offset),                                                              \
+     is_fldsd_c(Rs, Rd, offset),                                                       \
+     fld_c(Rd, Rs, offset)                                                             \
+  )
+
+// --------------------------
+// fsd -> c.fsdsp/c.fsd
+#define EMIT_MAY_COMPRESS_fsd(Rd, Rs, offset)                                          \
+  EMIT_RVC_cond2(,                                                                     \
+     is_fldsdsp_c(Rs, offset),                                                         \
+     fsdsp_c(Rd, offset),                                                              \
+     is_fldsd_c(Rs, Rd, offset),                                                       \
+     fsd_c(Rd, Rs, offset)                                                             \
+  )
+
+// --------------------------
+// Conditional branch instructions
+// --------------------------
+// beq/bne -> c.beqz/c.bnez
+
+// TODO: Removing the below 'offset != 0' check needs us to fix lots of '__ beqz() / __ benz()'
+//   to '__ beqz_nc() / __ bnez_nc()' everywhere.
+#define EMIT_MAY_COMPRESS_beqz_bnez_helper(NAME_C, Rs1, Rs2, offset)                   \
+  EMIT_RVC_cond(,                                                                      \
+    offset != 0 && Rs2 == x0 && Rs1->is_compressed_valid() &&                          \
+      is_imm_in_range(offset, 8, 1),                                                   \
+    NAME_C(Rs1, offset)                                                                \
+  )
+
+#define EMIT_MAY_COMPRESS_beq(Rs1, Rs2, offset)                                        \
+  EMIT_MAY_COMPRESS_beqz_bnez_helper(beqz_c, Rs1, Rs2, offset)
+
+#define EMIT_MAY_COMPRESS_bne(Rs1, Rs2, offset)                                        \
+  EMIT_MAY_COMPRESS_beqz_bnez_helper(bnez_c, Rs1, Rs2, offset)
+
+// --------------------------
+// Unconditional branch instructions
+// --------------------------
+// jalr/jal -> c.jr/c.jalr/c.j
+
+#define EMIT_MAY_COMPRESS_jalr(Rd, Rs, offset)                                         \
+  EMIT_RVC_cond2(,                                                                     \
+    offset == 0 && Rd == x1 && Rs != x0,                                               \
+    jalr_c(Rs),                                                                        \
+    offset == 0 && Rd == x0 && Rs != x0,                                               \
+    jr_c(Rs)                                                                           \
+  )
+
+// TODO: Removing the 'offset != 0' check needs us to fix lots of '__ j()'
+//   to '__ j_nc()' manually everywhere.
+#define EMIT_MAY_COMPRESS_jal(Rd, offset)                                              \
+  EMIT_RVC_cond(,                                                                      \
+    offset != 0 && Rd == x0 && is_imm_in_range(offset, 11, 1),                         \
+    j_c(offset)                                                                        \
+  )
+
+// --------------------------
+// Upper Immediate Instruction
+// --------------------------
+// lui -> c.lui
+#define EMIT_MAY_COMPRESS_lui(Rd, imm)                                                 \
+  EMIT_RVC_cond(,                                                                      \
+    Rd != x0 && Rd != x2 && imm != 0 && is_imm_in_range(imm, 18, 0),                   \
+    lui_c(Rd, imm)                                                                     \
+  )
+
+// --------------------------
+// Miscellaneous Instructions
+// --------------------------
+// ebreak -> c.ebreak
+#define EMIT_MAY_COMPRESS_ebreak()                                                     \
+  EMIT_RVC_cond(,                                                                      \
+    true,                                                                              \
+    ebreak_c()                                                                         \
+  )
+
+// --------------------------
+// Immediate Instructions
+// --------------------------
+// addi -> c.addi16sp/c.addi4spn/c.mv/c.addi/. An addi instruction able to transform to c.nop will be ignored.
+#define EMIT_MAY_COMPRESS_addi(Rd, Rs1, imm)                                                          \
+  EMIT_RVC_cond4(,                                                                                    \
+    Rs1 == sp && Rd == Rs1 && imm != 0 && (imm & 0b1111) == 0x0 && is_imm_in_range(imm, 10, 0),       \
+    addi16sp_c(imm),                                                                                  \
+    Rs1 == sp && Rd->is_compressed_valid() && imm != 0 && (imm & 0b11) == 0x0 && is_unsigned_imm_in_range(imm, 10, 0),  \
+    addi4spn_c(Rd, imm),                                                                              \
+    Rd == Rs1 && is_imm_in_range(imm, 6, 0),                                                          \
+    if (imm != 0) { addi_c(Rd, imm); },                                                               \
+    imm == 0 && Rd != x0 && Rs1 != x0,                                                                \
+    mv_c(Rd, Rs1)                                                                                     \
+  )
+
+// --------------------------
+// addiw -> c.addiw
+#define EMIT_MAY_COMPRESS_addiw(Rd, Rs1, imm)                                          \
+  EMIT_RVC_cond(,                                                                      \
+    Rd == Rs1 && Rd != x0 && is_imm_in_range(imm, 6, 0),                               \
+    addiw_c(Rd, imm)                                                                   \
+  )
+
+// --------------------------
+// and_imm12 -> c.andi
+#define EMIT_MAY_COMPRESS_and_imm12(Rd, Rs1, imm)                                      \
+  EMIT_RVC_cond(,                                                                      \
+    Rd == Rs1 && Rd->is_compressed_valid() && is_imm_in_range(imm, 6, 0),              \
+    andi_c(Rd, imm)                                                                    \
+  )
+
+// --------------------------
+// Shift Immediate Instructions
+// --------------------------
+// slli -> c.slli
+#define EMIT_MAY_COMPRESS_slli(Rd, Rs1, shamt)                                         \
+  EMIT_RVC_cond(,                                                                      \
+    Rd == Rs1 && Rd != x0 && shamt != 0,                                               \
+    slli_c(Rd, shamt)                                                                  \
+  )
+
+// --------------------------
+// srai/srli -> c.srai/c.srli
+#define EMIT_MAY_COMPRESS_srai_srli_helper(NAME_C, Rd, Rs1, shamt)                     \
+  EMIT_RVC_cond(,                                                                      \
+    Rd == Rs1 && Rd->is_compressed_valid() && shamt != 0,                              \
+    NAME_C(Rd, shamt)                                                                  \
+  )
+
+#define EMIT_MAY_COMPRESS_srai(Rd, Rs1, shamt)                                         \
+  EMIT_MAY_COMPRESS_srai_srli_helper(srai_c, Rd, Rs1, shamt)
+
+#define EMIT_MAY_COMPRESS_srli(Rd, Rs1, shamt)                                         \
+  EMIT_MAY_COMPRESS_srai_srli_helper(srli_c, Rd, Rs1, shamt)
+
+// --------------------------
+
+// a compile time dispatcher
+#define EMIT_MAY_COMPRESS_NAME_true(NAME, ARGS)            NAME ARGS
+#define EMIT_MAY_COMPRESS_NAME_false(NAME, ARGS)           NAME##_nc ARGS
+#define EMIT_MAY_COMPRESS_NAME(COMPRESSIBLE, NAME, ARGS)   EMIT_MAY_COMPRESS_NAME_##COMPRESSIBLE(NAME, ARGS)
+
+// a runtime dispatcher (if clause is needed)
+#define EMIT_MAY_COMPRESS_INST(COMPRESSIBLE, NAME, ARGS) \
+  if (COMPRESSIBLE) {                                    \
+    EMIT_MAY_COMPRESS_NAME_true(NAME, ARGS);             \
+  } else {                                               \
+    EMIT_MAY_COMPRESS_NAME_false(NAME, ARGS);            \
+  }
+
+#endif // CPU_RISCV_ASSEMBLER_RISCV_CEXT_HPP

--- a/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
@@ -44,7 +44,7 @@ void C1SafepointPollStub::emit_code(LIR_Assembler* ce)
   __ bind(_entry);
   InternalAddress safepoint_pc(__ pc() - __ offset() + safepoint_offset());
   __ code_section()->relocate(__ pc(), safepoint_pc.rspec());
-  __ la(t0, safepoint_pc.target());
+  __ la(t0, safepoint_pc.target(), NOT_COMPRESSIBLE);
   __ sd(t0, Address(xthread, JavaThread::saved_exception_pc_offset()));
 
   assert(SharedRuntime::polling_page_return_handler_blob() != NULL,
@@ -106,9 +106,7 @@ void RangeCheckStub::emit_code(LIR_Assembler* ce)
     __ mv(t1, _array->as_pointer_register());
     stub_id = Runtime1::throw_range_check_failed_id;
   }
-  int32_t off = 0;
-  __ la_patchable(ra, RuntimeAddress(Runtime1::entry_for(stub_id)), off);
-  __ jalr(ra, ra, off);
+  __ jalr_patchable(ra, RuntimeAddress(Runtime1::entry_for(stub_id)), ra);
   ce->add_call_info_here(_info);
   ce->verify_oop_map(_info);
   debug_only(__ should_not_reach_here());
@@ -257,7 +255,7 @@ void MonitorExitStub::emit_code(LIR_Assembler* ce)
   __ far_jump(RuntimeAddress(Runtime1::entry_for(exit_id)));
 }
 
-int PatchingStub::_patch_info_offset = -NativeGeneralJump::instruction_size;
+int PatchingStub::_patch_info_offset = -NativeGeneralJump::get_instruction_size();
 
 void PatchingStub::align_patch_site(MacroAssembler* masm) {}
 

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -325,7 +325,7 @@ void C1_MacroAssembler::verified_entry() {
   // must ensure that this first instruction is a J, JAL or NOP.
   // Make it a NOP.
 
-  nop();
+  nop_nc();
 }
 
 void C1_MacroAssembler::load_parameter(int offset_in_words, Register reg) {

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -67,9 +67,7 @@ int StubAssembler::call_RT(Register oop_result, Register metadata_result, addres
   set_last_Java_frame(sp, fp, retaddr, t0);
 
   // do the call
-  int32_t off = 0;
-  la_patchable(t0, RuntimeAddress(entry), off);
-  jalr(x1, t0, off);
+  jalr_patchable(x1, RuntimeAddress(entry), t0);
   bind(retaddr);
   int call_offset = offset();
   // verify callee-saved register
@@ -569,9 +567,7 @@ OopMapSet* Runtime1::generate_patching(StubAssembler* sasm, address target) {
   Label retaddr;
   __ set_last_Java_frame(sp, fp, retaddr, t0);
   // do the call
-  int32_t off = 0;
-  __ la_patchable(t0, RuntimeAddress(target), off);
-  __ jalr(x1, t0, off);
+  __ jalr_patchable(x1, RuntimeAddress(target), t0);
   __ bind(retaddr);
   OopMapSet* oop_maps = new OopMapSet();
   assert_cond(oop_maps != NULL);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1196,21 +1196,21 @@ typedef void (MacroAssembler::*float_conditional_branch_insn)(FloatRegister op1,
 static conditional_branch_insn conditional_branches[] =
 {
   /* SHORT branches */
-  (conditional_branch_insn)&Assembler::beq,
+  (conditional_branch_insn)&Assembler::beq_nc,
   (conditional_branch_insn)&Assembler::bgt,
   NULL, // BoolTest::overflow
   (conditional_branch_insn)&Assembler::blt,
-  (conditional_branch_insn)&Assembler::bne,
+  (conditional_branch_insn)&Assembler::bne_nc,
   (conditional_branch_insn)&Assembler::ble,
   NULL, // BoolTest::no_overflow
   (conditional_branch_insn)&Assembler::bge,
 
   /* UNSIGNED branches */
-  (conditional_branch_insn)&Assembler::beq,
+  (conditional_branch_insn)&Assembler::beq_nc,
   (conditional_branch_insn)&Assembler::bgtu,
   NULL,
   (conditional_branch_insn)&Assembler::bltu,
-  (conditional_branch_insn)&Assembler::bne,
+  (conditional_branch_insn)&Assembler::bne_nc,
   (conditional_branch_insn)&Assembler::bleu,
   NULL,
   (conditional_branch_insn)&Assembler::bgeu
@@ -1259,11 +1259,11 @@ void C2_MacroAssembler::enc_cmpUEqNeLeGt_imm0_branch(int cmpFlag, Register op1, 
   switch (cmpFlag) {
     case BoolTest::eq:
     case BoolTest::le:
-      beqz(op1, L, is_far);
+      beqz_nc(op1, L, is_far);
       break;
     case BoolTest::ne:
     case BoolTest::gt:
-      bnez(op1, L, is_far);
+      bnez_nc(op1, L, is_far);
       break;
     default:
       ShouldNotReachHere();
@@ -1273,10 +1273,10 @@ void C2_MacroAssembler::enc_cmpUEqNeLeGt_imm0_branch(int cmpFlag, Register op1, 
 void C2_MacroAssembler::enc_cmpEqNe_imm0_branch(int cmpFlag, Register op1, Label& L, bool is_far) {
   switch (cmpFlag) {
     case BoolTest::eq:
-      beqz(op1, L, is_far);
+      beqz_nc(op1, L, is_far);
       break;
     case BoolTest::ne:
-      bnez(op1, L, is_far);
+      bnez_nc(op1, L, is_far);
       break;
     default:
       ShouldNotReachHere();

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -82,6 +82,16 @@
   static const int double_branch_mask = 1 << bool_test_bits;
 
   // cmp
+  // C-Ext: these cmp functions remain uncompressed in C2 MachNodes' emission -
+  //   as the reason described in MachEpilogNode::emit() in PhaseOutput::scratch_emit_size()
+  //   it simulates a node's size, but for MachBranchNodes it emits a fake Label just
+  //   near the node itself - the offset is so small that in scratch emission phase it always
+  //   get compressed in our implicit compression phase - but in real world the Label may be
+  //   anywhere so it may not be compressed, so here is the mismatch: it runs shorten_branches();
+  //   but with C-Ext we may need a further, say, shorten_compressed_branches() or something.
+  //   After researching we find performance will not have much enhancement even if compressing
+  //   them and the cost is a bit big to support MachBranchNodes' compression.
+  //   So as a solution, we can simply disable the compression of MachBranchNodes.
   void cmp_branch(int cmpFlag,
                   Register op1, Register op2,
                   Label& label, bool is_far = false);

--- a/src/hotspot/cpu/riscv/c2_globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_globals_riscv.hpp
@@ -46,7 +46,7 @@ define_pd_global(intx, OnStackReplacePercentage,     140);
 define_pd_global(intx, ConditionalMoveLimit,         0);
 define_pd_global(intx, FreqInlineSize,               325);
 define_pd_global(intx, MinJumpTableSize,             10);
-define_pd_global(intx, InteriorEntryAlignment,       16);
+define_pd_global(intx, InteriorEntryAlignment,       4);
 define_pd_global(intx, NewSizeThreadIncrease, ScaleForWordSize(4*K));
 define_pd_global(intx, LoopUnrollLimit,              60);
 define_pd_global(intx, LoopPercentProfileLimit,      10);

--- a/src/hotspot/cpu/riscv/c2_safepointPollStubTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_safepointPollStubTable_riscv.cpp
@@ -41,7 +41,7 @@ void C2SafepointPollStubTable::emit_stub_impl(MacroAssembler& masm, C2SafepointP
   __ bind(entry->_stub_label);
   InternalAddress safepoint_pc(masm.pc() - masm.offset() + entry->_safepoint_offset);
   masm.code_section()->relocate(masm.pc(), safepoint_pc.rspec());
-  __ la(t0, safepoint_pc.target());
+  __ la(t0, safepoint_pc.target(), NOT_COMPRESSIBLE);
   __ sd(t0, Address(xthread, JavaThread::saved_exception_pc_offset()));
   __ far_jump(callback_addr);
 }

--- a/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
+++ b/src/hotspot/cpu/riscv/compiledIC_riscv.cpp
@@ -69,8 +69,12 @@ address CompiledStaticCall::emit_to_interp_stub(CodeBuffer &cbuf, address mark) 
 #undef __
 
 int CompiledStaticCall::to_interp_stub_size() {
-  // fence_i + fence* + (lui, addi, slli, addi, slli, addi) + (lui, addi, slli, addi, slli) + jalr
-  return NativeFenceI::instruction_size() + 12 * NativeInstruction::instruction_size;
+  // fence_i + fence* + (lui, addi, slli(C), addi, slli(C), addi) + (lui, addi, slli(C), addi, slli(C)) + jalr
+  return NativeFenceI::instruction_size() +
+         (!UseRVC ?
+           12 * NativeInstruction::instruction_size :
+           8 * NativeInstruction::instruction_size + 4 * NativeInstruction::compressed_instruction_size
+         );
 }
 
 int CompiledStaticCall::to_trampoline_stub_size() {

--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
@@ -336,9 +336,7 @@ void ZBarrierSetAssembler::generate_c2_load_barrier_stub(MacroAssembler* masm, Z
   {
     ZSaveLiveRegisters save_live_registers(masm, stub);
     ZSetupArguments setup_arguments(masm, stub);
-    int32_t offset = 0;
-    __ la_patchable(t0, stub->slow_path(), offset);
-    __ jalr(x1, t0, offset);
+    __ jalr_patchable(x1, stub->slow_path(), t0);
   }
 
   // Stub exit

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -37,7 +37,7 @@ define_pd_global(bool, TrapBasedNullChecks,      false);
 define_pd_global(bool, UncommonNullCast,         true);  // Uncommon-trap NULLs past to check cast
 
 define_pd_global(uintx, CodeCacheSegmentSize,    64 COMPILER1_AND_COMPILER2_PRESENT(+64)); // Tiered compilation has large code-entry alignment.
-define_pd_global(intx, CodeEntryAlignment,       64);
+define_pd_global(intx, CodeEntryAlignment,       16);
 define_pd_global(intx, OptoLoopAlignment,        16);
 
 #define DEFAULT_STACK_YELLOW_PAGES (2)
@@ -90,6 +90,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Extend fence.i to fence.i + fence.")                                  \
   product(bool, AvoidUnalignedAccesses, true,                                    \
           "Avoid generating unaligned memory accesses")                          \
-  product(bool, UseRVV, false, EXPERIMENTAL, "Use RVV instructions")
+  product(bool, UseRVV, false, EXPERIMENTAL, "Use RVV instructions")             \
+  product(bool, UseRVC, true, EXPERIMENTAL, "Use RVC instructions")              \
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -182,9 +182,7 @@ void InterpreterMacroAssembler::get_unsigned_2_byte_index_at_bcp(Register reg, i
 }
 
 void InterpreterMacroAssembler::get_dispatch() {
-  int32_t offset = 0;
-  la_patchable(xdispatch, ExternalAddress((address)Interpreter::dispatch_table()), offset);
-  addi(xdispatch, xdispatch, offset);
+  addi_patchable(xdispatch, ExternalAddress((address)Interpreter::dispatch_table()), xdispatch);
 }
 
 void InterpreterMacroAssembler::get_cache_index_at_bcp(Register index,

--- a/src/hotspot/cpu/riscv/jniFastGetField_riscv.cpp
+++ b/src/hotspot/cpu/riscv/jniFastGetField_riscv.cpp
@@ -74,9 +74,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
   address fast_entry = __ pc();
 
   Label slow;
-  int32_t offset = 0;
-  __ la_patchable(rcounter_addr, SafepointSynchronize::safepoint_counter_addr(), offset);
-  __ addi(rcounter_addr, rcounter_addr, offset);
+  __ addi_patchable(rcounter_addr, SafepointSynchronize::safepoint_counter_addr(), rcounter_addr);
 
   Address safepoint_counter_addr(rcounter_addr, 0);
   __ lwu(rcounter, safepoint_counter_addr);
@@ -169,9 +167,7 @@ address JNI_FastGetField::generate_fast_get_int_field0(BasicType type) {
 
   {
     __ enter();
-    int32_t tmp_offset = 0;
-    __ la_patchable(t0, ExternalAddress(slow_case_addr), tmp_offset);
-    __ jalr(x1, t0, tmp_offset);
+    __ jalr_patchable(x1, ExternalAddress(slow_case_addr), t0);
     __ leave();
     __ ret();
   }

--- a/src/hotspot/cpu/riscv/register_riscv.hpp
+++ b/src/hotspot/cpu/riscv/register_riscv.hpp
@@ -58,7 +58,11 @@ class RegisterImpl: public AbstractRegisterImpl {
   enum {
     number_of_registers      = 32,
     number_of_byte_registers = 32,
-    max_slots_per_register   = 2
+    max_slots_per_register   = 2,
+
+    // C-Ext: integer registers in the range of [x8~x15] are correspond for RVC. Please see Table 16.2 in spec.
+    compressed_register_base = 8,
+    compressed_register_top  = 15,
   };
 
   // derived registers, offsets, and addresses
@@ -71,10 +75,13 @@ class RegisterImpl: public AbstractRegisterImpl {
 
   // accessors
   int   encoding() const                         { assert(is_valid(), "invalid register"); return (intptr_t)this; }
+  int   compressed_encoding() const              { assert(is_compressed_valid(), "invalid compressed register"); return ((intptr_t)this - compressed_register_base); }
   bool  is_valid() const                         { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
+  bool  is_compressed_valid() const              { return compressed_register_base <= (intptr_t)this && (intptr_t)this <= compressed_register_top; }
   bool  has_byte_register() const                { return 0 <= (intptr_t)this && (intptr_t)this < number_of_byte_registers; }
   const char* name() const;
   int   encoding_nocheck() const                 { return (intptr_t)this; }
+  int   compressed_encoding_nocheck() const      { return ((intptr_t)this - compressed_register_base); }
 
   // Return the bit which represents this register.  This is intended
   // to be ORed into a bitmask: for usage see class RegSet below.
@@ -131,7 +138,11 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
  public:
   enum {
     number_of_registers     = 32,
-    max_slots_per_register  = 2
+    max_slots_per_register  = 2,
+
+    // C-Ext: float registers in the range of [f8~f15] are correspond for RVC. Please see Table 16.2 in spec.
+    compressed_register_base = 8,
+    compressed_register_top  = 15,
   };
 
   // construction
@@ -144,8 +155,11 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
 
   // accessors
   int   encoding() const                          { assert(is_valid(), "invalid register"); return (intptr_t)this; }
+  int   compressed_encoding() const               { assert(is_compressed_valid(), "invalid compressed register"); return ((intptr_t)this - compressed_register_base); }
   int   encoding_nocheck() const                         { return (intptr_t)this; }
+  int   compressed_encoding_nocheck() const       { return ((intptr_t)this - compressed_register_base); }
   bool  is_valid() const                          { return 0 <= (intptr_t)this && (intptr_t)this < number_of_registers; }
+  bool  is_compressed_valid() const               { return compressed_register_base <= (intptr_t)this && (intptr_t)this <= compressed_register_top; }
   const char* name() const;
 
 };

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1156,14 +1156,15 @@ bool needs_acquiring_load_reserved(const Node *n)
 
 int MachCallStaticJavaNode::ret_addr_offset()
 {
-  // call should be a simple jal
-  int off = 4;
-  return off;
+  // jal
+  return 1 * NativeInstruction::instruction_size;
 }
 
 int MachCallDynamicJavaNode::ret_addr_offset()
 {
-  return 28; // movptr, jal
+  return 4 * NativeInstruction::instruction_size +
+         2 * (!UseRVC ? NativeInstruction::instruction_size : NativeInstruction::compressed_instruction_size) +
+         1 * NativeInstruction::instruction_size; // movptr, jal
 }
 
 int MachCallRuntimeNode::ret_addr_offset() {
@@ -1171,25 +1172,67 @@ int MachCallRuntimeNode::ret_addr_offset() {
   //   jal(addr)
   // or with far branches
   //   jal(trampoline_stub)
-  // for real runtime callouts it will be six instructions
+  // for real runtime callouts it will be 12 instructions
   // see riscv64_enc_java_to_runtime
-  //   la(t1, retaddr)
-  //   la(t0, RuntimeAddress(addr))
-  //   addi(sp, sp, -2 * wordSize)
-  //   sd(zr, Address(sp))
-  //   sd(t1, Address(sp, wordSize))
-  //   jalr(t0)
+  //   la(t1, retaddr)                ->  auipc + addi
+  //   la(t0, RuntimeAddress(addr))   ->  lui + addi + slli(C) + addi + slli(C) + addi
+  //   addi(sp, sp, -2 * wordSize)    ->  addi(C)
+  //   sd(zr, Address(sp))            ->  sd(C)
+  //   sd(t1, Address(sp, wordSize))  ->  sd(C)
+  //   jalr(t0)                       ->  jalr(C)
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
   if (cb != NULL) {
     return 1 * NativeInstruction::instruction_size;
   } else {
-    return 12 * NativeInstruction::instruction_size;
+    const int instruction_size = NativeInstruction::instruction_size;
+    const int compressed_instruction_size = (!UseRVC ? instruction_size : NativeInstruction::compressed_instruction_size);
+    return 2 * instruction_size +
+           4 * instruction_size + 2 * compressed_instruction_size +
+           1 * compressed_instruction_size +
+           1 * compressed_instruction_size +
+           1 * compressed_instruction_size +
+           1 * compressed_instruction_size;
   }
 }
 
 int MachCallNativeNode::ret_addr_offset() {
   Unimplemented();
   return -1;
+}
+
+// C-Ext: With C-Ext a call may get 2-byte aligned.
+//   The offset encoding in jal ranges bits [12, 31], which could span the cache line.
+//   Patching this unaligned address will make the write operation not atomic.
+//   Other threads may be running the same piece of code at full speed, causing concurrency issues.
+//   So we must ensure that it does not span a cache line so that it can be patched.
+int CallStaticJavaDirectNode::compute_padding(int current_offset) const
+{
+  // to make sure the address of jal 4-byte aligned.
+  return align_up(current_offset, alignment_required()) - current_offset;
+}
+
+// C-Ext: With C-Ext a call may get 2-byte aligned.
+//   The offset encoding in jal ranges bits [12, 31], which could span the cache line.
+//   Patching this unaligned address will make the write operation not atomic.
+//   Other threads may be running the same piece of code at full speed, causing concurrency issues.
+//   So we must ensure that it does not span a cache line so that it can be patched.
+int CallDynamicJavaDirectNode::compute_padding(int current_offset) const
+{
+  // skip the movptr in MacroAssembler::ic_call():
+  // lui + addi + slli(C) + addi + slli(C) + addi
+  // Though movptr() has already 4-byte aligned with or without C-Ext,
+  // We need to prevent from further changes by explicitly calculating the size.
+  const int instruction_size = NativeInstruction::instruction_size;
+  const int compressed_instruction_size = (!UseRVC ? instruction_size : NativeInstruction::compressed_instruction_size);
+  const int movptr_size =
+         2 * instruction_size +
+         1 * compressed_instruction_size +
+         1 * instruction_size +
+         1 * compressed_instruction_size +
+         1 * instruction_size;
+  current_offset += movptr_size;
+  // to make sure the address of jal 4-byte aligned.
+  return align_up(current_offset, alignment_required()) - current_offset;
 }
 
 //=============================================================================
@@ -1226,7 +1269,7 @@ uint MachBreakpointNode::size(PhaseRegAlloc *ra_) const {
   }
 
   uint MachNopNode::size(PhaseRegAlloc*) const {
-    return _count * NativeInstruction::instruction_size;
+    return _count * (!UseRVC ? NativeInstruction::instruction_size : NativeInstruction::compressed_instruction_size);
   }
 
 //=============================================================================
@@ -1295,7 +1338,7 @@ void MachPrologNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
 
   // insert a nop at the start of the prolog so we can patch in a
   // branch if we need to invalidate the method later
-  __ nop();
+  __ nop_nc();  // 4 bytes
 
   assert_cond(C != NULL);
 
@@ -1387,7 +1430,14 @@ void MachEpilogNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   __ remove_frame(framesize);
 
   if (StackReservedPages > 0 && C->has_reserved_stack_access()) {
-    __ reserved_stack_check();
+    // C-Ext: we need to emit instructions of the same constant size here.
+    //   This Node will emit should_not_reach_here(), further emitting a movptr of pc() address.
+    //   However, C2 will do PhaseOutput::scratch_emit_size() to simulate the size of Node -
+    //   this time, the pc() is a different value from the final emission and it may get compressed.
+    //   We may get a case that Node size is different between scratch_emit and real emission phase,
+    //   which are not allowed. So we need to emit the same constant size by disabling compression
+    //   of the movptr of pc() to align with the logic.
+    __ reserved_stack_check(NOT_COMPRESSIBLE);
   }
 
   if (do_polling() && C->is_method_compilation()) {
@@ -1644,7 +1694,8 @@ void BoxLockNode::emit(CodeBuffer &cbuf, PhaseRegAlloc *ra_) const {
   int reg    = ra_->get_encode(this);
 
   if (is_imm_in_range(offset, 12, 0)) {
-    __ addi(as_Register(reg), sp, offset);
+    // C-Ext: See BoxLockNode::size(). We need to manually calculate this node's size.
+    __ addi_nc(as_Register(reg), sp, offset);
   } else if (is_imm_in_range(offset, 32, 0)) {
     __ li32(t0, offset);
     __ add(as_Register(reg), sp, t0);
@@ -9792,6 +9843,7 @@ instruct CallStaticJavaDirect(method meth)
               riscv64_enc_call_epilog );
 
   ins_pipe(pipe_class_call);
+  ins_alignment(4);
 %}
 
 // TO HERE
@@ -9811,6 +9863,7 @@ instruct CallDynamicJavaDirect(method meth, rFlagsReg cr)
                riscv64_enc_call_epilog );
 
   ins_pipe(pipe_class_call);
+  ins_alignment(4);
 %}
 
 // Call Runtime Instruction

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -348,9 +348,7 @@ static void patch_callers_callsite(MacroAssembler *masm) {
 
   __ mv(c_rarg0, xmethod);
   __ mv(c_rarg1, ra);
-  int32_t offset = 0;
-  __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::fixup_callers_callsite)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_patchable(x1, RuntimeAddress(CAST_FROM_FN_PTR(address, SharedRuntime::fixup_callers_callsite)), t0);
 
   // Explicit fence.i required because fixup_callers_callsite may change the code
   // stream.
@@ -1020,9 +1018,7 @@ static void rt_call(MacroAssembler* masm, address dest) {
   if (cb) {
     __ far_call(RuntimeAddress(dest));
   } else {
-    int32_t offset = 0;
-    __ la_patchable(t0, RuntimeAddress(dest), offset);
-    __ jalr(x1, t0, offset);
+    __ jalr_patchable(x1, RuntimeAddress(dest), t0);
   }
 }
 
@@ -1147,7 +1143,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
     int vep_offset = ((intptr_t)__ pc()) - start;
 
     // First instruction must be a nop as it may need to be patched on deoptimisation
-    __ nop();
+    __ nop_nc();
     gen_special_dispatch(masm,
                          method,
                          in_sig_bt,
@@ -1298,7 +1294,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 
   // If we have to make this method not-entrant we'll overwrite its
   // first instruction with a jump.
-  __ nop();
+  __ nop_nc();
 
   if (VM_Version::supports_fast_class_init_checks() && method->needs_clinit_barrier()) {
     Label L_skip_barrier;
@@ -1799,9 +1795,7 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
 #ifndef PRODUCT
     assert(frame::arg_reg_save_area_bytes == 0, "not expecting frame reg save area");
 #endif
-    int32_t offset = 0;
-    __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans)), offset);
-    __ jalr(x1, t0, offset);
+    __ jalr_patchable(x1, RuntimeAddress(CAST_FROM_FN_PTR(address, JavaThread::check_special_condition_for_native_trans)), t0);
 
     // Restore any method result value
     restore_native_result(masm, ret_type, stack_slots);
@@ -2018,9 +2012,7 @@ void SharedRuntime::generate_deopt_blob() {
 #endif // ASSERT
   __ mv(c_rarg0, xthread);
   __ mv(c_rarg1, xcpool);
-  int32_t offset = 0;
-  __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::fetch_unroll_info)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_patchable(x1, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::fetch_unroll_info)), t0);
   __ bind(retaddr);
 
   // Need to have an oopmap that tells fetch_unroll_info where to
@@ -2156,9 +2148,7 @@ void SharedRuntime::generate_deopt_blob() {
 
   __ mv(c_rarg0, xthread);
   __ mv(c_rarg1, xcpool); // second arg: exec_mode
-  offset = 0;
-  __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_patchable(x1, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames)), t0);
 
   // Set an oopmap for the call site
   // Use the same PC we used for the last java frame
@@ -2242,11 +2232,9 @@ void SharedRuntime::generate_uncommon_trap_blob() {
 
   __ mv(c_rarg0, xthread);
   __ mvw(c_rarg2, (unsigned)Deoptimization::Unpack_uncommon_trap);
-  int32_t offset = 0;
-  __ la_patchable(t0,
+  __ jalr_patchable(x1,
         RuntimeAddress(CAST_FROM_FN_PTR(address,
-                                        Deoptimization::uncommon_trap)), offset);
-  __ jalr(x1, t0, offset);
+                                        Deoptimization::uncommon_trap)), t0);
   __ bind(retaddr);
 
   // Set an oopmap for the call site
@@ -2368,9 +2356,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   // sp should already be aligned
   __ mv(c_rarg0, xthread);
   __ mvw(c_rarg1, (unsigned)Deoptimization::Unpack_uncommon_trap);
-  offset = 0;
-  __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_patchable(x1, RuntimeAddress(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames)), t0);
 
   // Set an oopmap for the call site
   // Use the same PC we used for the last java frame
@@ -2439,9 +2425,7 @@ SafepointBlob* SharedRuntime::generate_handler_blob(address call_ptr, int poll_t
 
   // Do the call
   __ mv(c_rarg0, xthread);
-  int32_t offset = 0;
-  __ la_patchable(t0, RuntimeAddress(call_ptr), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_patchable(x1, RuntimeAddress(call_ptr), t0);
   __ bind(retaddr);
 
   // Set an oopmap for the call site.  This oopmap will map all
@@ -2549,9 +2533,7 @@ RuntimeStub* SharedRuntime::generate_resolve_blob(address destination, const cha
     __ set_last_Java_frame(sp, noreg, retaddr, t0);
 
     __ mv(c_rarg0, xthread);
-    int32_t offset = 0;
-    __ la_patchable(t0, RuntimeAddress(destination), offset);
-    __ jalr(x1, t0, offset);
+    __ jalr_patchable(x1, RuntimeAddress(destination), t0);
     __ bind(retaddr);
   }
 
@@ -2688,9 +2670,7 @@ void OptoRuntime::generate_exception_blob() {
   address the_pc = __ pc();
   __ set_last_Java_frame(sp, noreg, the_pc, t0);
   __ mv(c_rarg0, xthread);
-  int32_t offset = 0;
-  __ la_patchable(t0, RuntimeAddress(CAST_FROM_FN_PTR(address, OptoRuntime::handle_exception_C)), offset);
-  __ jalr(x1, t0, offset);
+  __ jalr_patchable(x1, RuntimeAddress(CAST_FROM_FN_PTR(address, OptoRuntime::handle_exception_C)), t0);
 
 
   // handle_exception_C is a special VM call which does not require an explicit

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -103,6 +103,12 @@ void VM_Version::get_processor_features() {
     FLAG_SET_DEFAULT(UseMD5Intrinsics, false);
   }
 
+  // compressed instruction extension
+  if (UseRVC && !(_features & CPU_C)) {
+    warning("RVC is not supported on this CPU");
+    FLAG_SET_DEFAULT(UseRVC, false);
+  }
+
   if (UseRVV) {
     if (!(_features & CPU_V)) {
       warning("RVV is not supported on this CPU");

--- a/src/hotspot/share/c1/c1_CodeStubs.hpp
+++ b/src/hotspot/share/c1/c1_CodeStubs.hpp
@@ -431,7 +431,7 @@ class PatchingStub: public CodeStub {
       NativeMovRegMem* n_move = nativeMovRegMem_at(pc_start());
       n_move->set_offset(field_offset);
       // Copy will never get executed, so only copy the part which is required for patching.
-      _bytes_to_copy = MAX2(n_move->num_bytes_to_end_of_patch(), (int)NativeGeneralJump::instruction_size);
+      _bytes_to_copy = MAX2(n_move->num_bytes_to_end_of_patch(), NOT_RISCV((int)NativeGeneralJump::instruction_size) RISCV_ONLY(NativeGeneralJump::get_instruction_size()));
     } else if (_id == load_klass_id || _id == load_mirror_id || _id == load_appendix_id) {
       assert(_obj != noreg, "must have register object for load_klass/load_mirror");
 #ifdef ASSERT

--- a/src/hotspot/share/c1/c1_LIRAssembler.cpp
+++ b/src/hotspot/share/c1/c1_LIRAssembler.cpp
@@ -40,7 +40,7 @@ void LIR_Assembler::patching_epilog(PatchingStub* patch, LIR_PatchCode patch_cod
   // We must have enough patching space so that call can be inserted.
   // We cannot use fat nops here, since the concurrent code rewrite may transiently
   // create the illegal instruction sequence.
-  while ((intx) _masm->pc() - (intx) patch->pc_start() < NativeGeneralJump::instruction_size) {
+  while ((intx) _masm->pc() - (intx) patch->pc_start() < NOT_RISCV(NativeGeneralJump::instruction_size) RISCV_ONLY(NativeGeneralJump::get_instruction_size()) ) {
     _masm->nop();
   }
   patch->install(_masm, patch_code, obj, info);

--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
+++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsCompiler.cpp
@@ -329,7 +329,7 @@ JVMFlag::Error InteriorEntryAlignmentConstraintFunc(intx value, bool verbose) {
    }
 
   int minimum_alignment = 16;
-#if defined(X86) && !defined(AMD64)
+#if (defined(X86) && !defined(AMD64)) || defined(RISCV)
   minimum_alignment = 4;
 #elif defined(S390)
   minimum_alignment = 2;


### PR DESCRIPTION
Hi team,

This patch support RISC-V RVC extension. It can introduce:
* 21% code size reduction in template interpreter generated code
* 20%~25% code size reduction in C1 generated code, evaluated by a common SpringBoot program
* 15%~20% code size reduction in C2 generated code, evaluated by a common SpringBoot program

In my observation, the code size footprint could be reduced to nearly a level of the AArch64 back-end. About the performance, there seems a stable ~0.7% performance improvement on SPECjbb2015 on one HiFive Unleashed board, considering the code density increase. I think the performance aspect might be a speculative behavior on different hardware implementations because C910's performance might be better than that, but HiFive Unleashed may be more general.

Things about this patch:
* If an instruction is compressible, then we will implicitly emit a 16-bit compressed instruction instead of the 32-bit instruction in Assembler.
* About the `_nc` postfix of some of Assembler instructions: we know a bunch of places should be reserved for patching, where we cannot change them into compressed instructions. `_nc` is short for `not compressible` - with this, those instructions should keep their origin 4-byte form and remain uncompressed.
* There are things not easy to compress like MachBranchNodes. Please see the comments in the code - currently this patch does not support this. We will support this improvement in patches coming afterward.

The macros after their expansion might be like:
```
void andr(Register Rd, Register Rs1, Register Rs2) {
+  {
+    Register src = noreg;
+    if (UseRVC && Rs1->is_compressed_valid() && Rs2->is_compressed_valid() &&
+        ((src = Rs1, Rs2 == Rd) || (src = Rs2, Rs1 == Rd))) {
+      and_c(Rd, src);
+      return;
+    }
+  }
  unsigned insn = 0;
  patch((address)&insn, 6, 0, 0b0110011);
  patch((address)&insn, 14, 12, 0b111);
  patch((address)&insn, 31, 25, 0b0000000);
  patch_reg((address)&insn, 7, Rd);
  patch_reg((address)&insn, 15, Rs1);
  patch_reg((address)&insn, 20, Rs2);
  emit(insn);
};
```

For further information, please see comments in `assembler_riscv_cext.hpp`.

\-\-

This patch may need some time to acquire a review. I have been polishing this patch for quite a long time and it might seem stable under a bunch of full-tier tests and some tier1 jdk/hotspot jtreg tests. But I think we might mark it `experimental` at first, though it is turned on by default. [The original patch](https://github.com/riscv-collab/riscv-openjdk/pull/7), just for reference, might be quite different from the current one.

I am pleased to receive any suggestion.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Issue
 * [JDK-8278322](https://bugs.openjdk.java.net/browse/JDK-8278322): riscv: Support RVC: compressed instructions


### Contributors
 * Wei Kuai `<kuaiwei.kw@alibaba-inc.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/24/head:pull/24` \
`$ git checkout pull/24`

Update a local copy of the PR: \
`$ git checkout pull/24` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/24/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 24`

View PR using the GUI difftool: \
`$ git pr show -t 24`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/24.diff">https://git.openjdk.java.net/riscv-port/pull/24.diff</a>

</details>
