### PR TITLE
8278337: riscv: remove unnecessary ld/sd zr around calls

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -953,14 +953,9 @@ void MacroAssembler::pop_reg(Register Rd)
 }
 
 int MacroAssembler::bitset_to_regs(unsigned int bitset, unsigned char* regs) {
-  DEBUG_ONLY(int words_pushed = 0;)
-
   int count = 0;
-  // Sp is x2, and zr is x0, which should not be pushed.
-  // If the number of registers is odd, zr is used for stack alignment.Otherwise, it will be ignored.
-  bitset &= ~ (1U << 2);
-  bitset |= 0x1;
-
+  // Zr and sp (x0, x2) should not be pushed
+  assert((bitset & 0b101) == 0, "zr or sp is in bitset: %x", bitset);
   // Scan bitset to accumulate register pairs
   for (int reg = 31; reg >= 0; reg --) {
     if ((1U << 31) & bitset) {
@@ -968,7 +963,6 @@ int MacroAssembler::bitset_to_regs(unsigned int bitset, unsigned char* regs) {
     }
     bitset <<= 1;
   }
-  count &= ~1;  // Only push an even number of regs
   return count;
 }
 
@@ -979,12 +973,14 @@ int MacroAssembler::push_reg(unsigned int bitset, Register stack) {
 
   unsigned char regs[32];
   int count = bitset_to_regs(bitset, regs);
+  // reserve one slot to align for odd count
+  int offset = is_even(count) ? 0 : wordSize;
 
   if (count) {
-    addi(stack, stack, - count * wordSize);
+    addi(stack, stack, - count * wordSize - offset);
   }
   for (int i = count - 1; i >= 0; i--) {
-    sd(as_Register(regs[i]), Address(stack, (count -1 - i) * wordSize));
+    sd(as_Register(regs[i]), Address(stack, (count -1 - i) * wordSize + offset));
     DEBUG_ONLY(words_pushed ++;)
   }
 
@@ -998,14 +994,16 @@ int MacroAssembler::pop_reg(unsigned int bitset, Register stack) {
 
   unsigned char regs[32];
   int count = bitset_to_regs(bitset, regs);
+  // reserve one slot to align for odd count
+  int offset = is_even(count) ? 0 : wordSize;
 
   for (int i = count - 1; i >= 0; i--) {
-    ld(as_Register(regs[i]), Address(stack, (count -1 - i) * wordSize));
+    ld(as_Register(regs[i]), Address(stack, (count - 1 - i) * wordSize + offset));
     DEBUG_ONLY(words_popped ++;)
   }
 
   if (count) {
-    addi(stack, stack, count * wordSize);
+    addi(stack, stack, count * wordSize + offset);
   }
   assert(words_popped == count, "oops, popped != count");
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -954,8 +954,6 @@ void MacroAssembler::pop_reg(Register Rd)
 
 int MacroAssembler::bitset_to_regs(unsigned int bitset, unsigned char* regs) {
   int count = 0;
-  // Zr and sp (x0, x2) should not be pushed
-  assert((bitset & 0b101) == 0, "zr or sp is in bitset: %x", bitset);
   // Scan bitset to accumulate register pairs
   for (int reg = 31; reg >= 0; reg --) {
     if ((1U << 31) & bitset) {
@@ -980,7 +978,7 @@ int MacroAssembler::push_reg(unsigned int bitset, Register stack) {
     addi(stack, stack, - count * wordSize - offset);
   }
   for (int i = count - 1; i >= 0; i--) {
-    sd(as_Register(regs[i]), Address(stack, (count -1 - i) * wordSize + offset));
+    sd(as_Register(regs[i]), Address(stack, (count - 1 - i) * wordSize + offset));
     DEBUG_ONLY(words_pushed ++;)
   }
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1180,19 +1180,18 @@ int MachCallRuntimeNode::ret_addr_offset() {
   //   jal(addr)
   // or with far branches
   //   jal(trampoline_stub)
-  // for real runtime callouts it will be six instructions
+  // for real runtime callouts it will be five instructions
   // see riscv64_enc_java_to_runtime
   //   la(t1, retaddr)
   //   la(t0, RuntimeAddress(addr))
   //   addi(sp, sp, -2 * wordSize)
-  //   sd(zr, Address(sp))
   //   sd(t1, Address(sp, wordSize))
   //   jalr(t0)
   CodeBlob *cb = CodeCache::find_blob(_entry_point);
   if (cb != NULL) {
     return 1 * NativeInstruction::instruction_size;
   } else {
-    return 12 * NativeInstruction::instruction_size;
+    return 11 * NativeInstruction::instruction_size;
   }
 }
 
@@ -2274,7 +2273,6 @@ encode %{
       __ la(t0, RuntimeAddress(entry));
       // Leave a breadcrumb for JavaFrameAnchor::capture_last_Java_pc()
       __ addi(sp, sp, -2 * wordSize);
-      __ sd(zr, Address(sp));
       __ sd(t1, Address(sp, wordSize));
       __ jalr(t0);
       __ bind(retaddr);


### PR DESCRIPTION
It seems zr(x0) is used as stack alignment when saving/restoring registers around calls. But it's unnecessary to ld/st x0 from/to stack. We just need reserve a stack slot in case alignment is required. It passed tier1 tests with fastdebug in qemu.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278337](https://bugs.openjdk.java.net/browse/JDK-8278337): riscv: remove unnecessary ld/sd zr around calls


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/25.diff">https://git.openjdk.java.net/riscv-port/pull/25.diff</a>

</details>
