### PR TITLE
8278387: riscv: Implement UseHeavyMonitors consistently

### DIFF
--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -330,7 +330,11 @@ int LIR_Assembler::emit_unwind_handler() {
   if (method()->is_synchronized()) {
     monitor_address(0, FrameMap::r10_opr);
     stub = new MonitorExitStub(FrameMap::r10_opr, true, 0);
-    __ unlock_object(x15, x14, x10, *stub->entry());
+    if (UseHeavyMonitors) {
+      __ j(*stub->entry());
+    } else {
+      __ unlock_object(x15, x14, x10, *stub->entry());
+    }
     __ bind(*stub->continuation());
   }
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2302,36 +2302,40 @@ encode %{
     __ andi(t0, disp_hdr, markWord::monitor_value);
     __ bnez(t0, object_has_monitor);
 
-    // Set tmp to be (markWord of object | UNLOCK_VALUE).
-    __ ori(tmp, disp_hdr, markWord::unlocked_value);
+    if (!UseHeavyMonitors) {
+      // Set tmp to be (markWord of object | UNLOCK_VALUE).
+      __ ori(tmp, disp_hdr, markWord::unlocked_value);
 
-    // Initialize the box. (Must happen before we update the object mark!)
-    __ sd(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      // Initialize the box. (Must happen before we update the object mark!)
+      __ sd(tmp, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
-    // Compare object markWord with an unlocked value (tmp) and if
-    // equal exchange the stack address of our box with object markWord.
-    // On failure disp_hdr contains the possibly locked markWord.
-    __ cmpxchg(/*memory address*/oop, /*expected value*/tmp, /*new value*/box, Assembler::int64, Assembler::aq,
-               Assembler::rl, /*result*/disp_hdr);
-    __ mv(flag, zr);
-    __ beq(disp_hdr, tmp, cont); // prepare zero flag and goto cont if we won the cas
+      // Compare object markWord with an unlocked value (tmp) and if
+      // equal exchange the stack address of our box with object markWord.
+      // On failure disp_hdr contains the possibly locked markWord.
+      __ cmpxchg(/*memory address*/oop, /*expected value*/tmp, /*new value*/box, Assembler::int64, Assembler::aq,
+                 Assembler::rl, /*result*/disp_hdr);
+      __ mv(flag, zr);
+      __ beq(disp_hdr, tmp, cont); // prepare zero flag and goto cont if we won the cas
 
-    assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
+      assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");
 
-    // If the compare-and-exchange succeeded, then we found an unlocked
-    // object, will have now locked it will continue at label cont
-    // We did not see an unlocked object so try the fast recursive case.
+      // If the compare-and-exchange succeeded, then we found an unlocked
+      // object, will have now locked it will continue at label cont
+      // We did not see an unlocked object so try the fast recursive case.
 
-    // Check if the owner is self by comparing the value in the
-    // markWord of object (disp_hdr) with the stack pointer.
-    __ sub(disp_hdr, disp_hdr, sp);
-    __ li(tmp, (intptr_t) (~(os::vm_page_size()-1) | (uintptr_t)markWord::lock_mask_in_place));
-    // If (mark & lock_mask) == 0 and mark - sp < page_size, we are stack-locking and goto cont,
-    // hence we can store 0 as the displaced header in the box, which indicates that it is a
-    // recursive lock.
-    __ andr(tmp/*==0?*/, disp_hdr, tmp);
-    __ sd(tmp/*==0, perhaps*/, Address(box, BasicLock::displaced_header_offset_in_bytes()));
-    __ mv(flag, tmp); // we can use the value of tmp as the result here
+      // Check if the owner is self by comparing the value in the
+      // markWord of object (disp_hdr) with the stack pointer.
+      __ sub(disp_hdr, disp_hdr, sp);
+      __ li(tmp, (intptr_t) (~(os::vm_page_size()-1) | (uintptr_t)markWord::lock_mask_in_place));
+      // If (mark & lock_mask) == 0 and mark - sp < page_size, we are stack-locking and goto cont,
+      // hence we can store 0 as the displaced header in the box, which indicates that it is a
+      // recursive lock.
+      __ andr(tmp/*==0?*/, disp_hdr, tmp);
+      __ sd(tmp/*==0, perhaps*/, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+      __ mv(flag, tmp); // we can use the value of tmp as the result here
+    } else {
+      __ mv(flag, 1); // Set non-zero flag to indicate 'failure' -> take slow-path
+    }
 
     __ j(cont);
 
@@ -2378,25 +2382,31 @@ encode %{
 
     assert_different_registers(oop, box, tmp, disp_hdr, flag);
 
-    // Find the lock address and load the displaced header from the stack.
-    __ ld(disp_hdr, Address(box, BasicLock::displaced_header_offset_in_bytes()));
+    if (!UseHeavyMonitors) {
+      // Find the lock address and load the displaced header from the stack.
+      __ ld(disp_hdr, Address(box, BasicLock::displaced_header_offset_in_bytes()));
 
-    // If the displaced header is 0, we have a recursive unlock.
-    __ mv(flag, disp_hdr);
-    __ beqz(disp_hdr, cont);
+      // If the displaced header is 0, we have a recursive unlock.
+      __ mv(flag, disp_hdr);
+      __ beqz(disp_hdr, cont);
+    }
 
     // Handle existing monitor.
     __ ld(tmp, Address(oop, oopDesc::mark_offset_in_bytes()));
     __ andi(t0, disp_hdr, markWord::monitor_value);
     __ bnez(t0, object_has_monitor);
 
-    // Check if it is still a light weight lock, this is true if we
-    // see the stack address of the basicLock in the markWord of the
-    // object.
-
-    __ cmpxchg(/*memory address*/oop, /*expected value*/box, /*new value*/disp_hdr, Assembler::int64, Assembler::relaxed,
-               Assembler::rl, /*result*/tmp);
-    __ xorr(flag, box, tmp); // box == tmp if cas succeeds
+    if (!UseHeavyMonitors) {
+      // Check if it is still a light weight lock, this is true if we
+      // see the stack address of the basicLock in the markWord of the
+      // object.
+  
+      __ cmpxchg(/*memory address*/oop, /*expected value*/box, /*new value*/disp_hdr, Assembler::int64, Assembler::relaxed,
+                 Assembler::rl, /*result*/tmp);
+      __ xorr(flag, box, tmp); // box == tmp if cas succeeds
+    } else {
+      __ mv(flag, 1); // Set non-zero flag to indicate 'failure' -> take slow path
+    }
     __ j(cont);
 
     assert(oopDesc::mark_offset_in_bytes() == 0, "offset of _mark is not 0");

--- a/src/hotspot/share/runtime/arguments.cpp
+++ b/src/hotspot/share/runtime/arguments.cpp
@@ -2022,7 +2022,7 @@ bool Arguments::check_vm_args_consistency() {
   }
 #endif
 
-#if !defined(X86) && !defined(AARCH64) && !defined(PPC64)
+#if !defined(X86) && !defined(AARCH64) && !defined(PPC64) && !defined(RISCV64)
   if (UseHeavyMonitors) {
     warning("UseHeavyMonitors is not fully implemented on this architecture");
   }

--- a/src/hotspot/share/runtime/synchronizer.cpp
+++ b/src/hotspot/share/runtime/synchronizer.cpp
@@ -418,7 +418,7 @@ void ObjectSynchronizer::handle_sync_on_value_based_class(Handle obj, JavaThread
 }
 
 static bool useHeavyMonitors() {
-#if defined(X86) || defined(AARCH64) || defined(PPC64)
+#if defined(X86) || defined(AARCH64) || defined(PPC64) || defined(RISCV64)
   return UseHeavyMonitors;
 #else
   return false;

--- a/test/jdk/java/util/concurrent/ConcurrentHashMap/MapLoops.java
+++ b/test/jdk/java/util/concurrent/ConcurrentHashMap/MapLoops.java
@@ -48,7 +48,7 @@
 /*
  * @test
  * @summary Exercise multithreaded maps, using only heavy monitors.
- * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch == "ppc64" | os.arch == "ppc64le"
+ * @requires os.arch=="x86" | os.arch=="i386" | os.arch=="amd64" | os.arch=="x86_64" | os.arch=="aarch64" | os.arch == "ppc64" | os.arch == "ppc64le" | os.arch == "riscv64"
  * @library /test/lib
  * @run main/othervm/timeout=1600 -XX:+IgnoreUnrecognizedVMOptions -XX:+UseHeavyMonitors -XX:+VerifyHeavyMonitors MapLoops
  */


### PR DESCRIPTION
Make hotspot always use inflated monitors consistently if the flag UseHeavyMonitors is true. The riscv platform should follow https://bugs.openjdk.java.net/browse/JDK-8276901.

Hotspot and jdk tier1 passed on the unmatched board. All jtreg tests were tested without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278387](https://bugs.openjdk.java.net/browse/JDK-8278387): riscv: Implement UseHeavyMonitors consistently


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/26.diff">https://git.openjdk.java.net/riscv-port/pull/26.diff</a>

</details>
