### PR TITLE
8278531: riscv: Remove duplicate code bitset_to_fregs

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -955,7 +955,7 @@ void MacroAssembler::pop_reg(Register Rd)
 int MacroAssembler::bitset_to_regs(unsigned int bitset, unsigned char* regs) {
   int count = 0;
   // Scan bitset to accumulate register pairs
-  for (int reg = 31; reg >= 0; reg --) {
+  for (int reg = 31; reg >= 0; reg--) {
     if ((1U << 31) & bitset) {
       regs[count++] = reg;
     }
@@ -1008,25 +1008,12 @@ int MacroAssembler::pop_reg(unsigned int bitset, Register stack) {
   return count;
 }
 
-int MacroAssembler::bitset_to_fregs(unsigned int bitset, unsigned char* regs) {
-  int count = 0;
-  // Scan bitset to accumulate register pairs
-  for (int reg = 31; reg >= 0; reg--) {
-    if ((1U << 31) & bitset) {
-      regs[count++] = reg;
-    }
-    bitset <<= 1;
-  }
-
-  return count;
-}
-
 // Push float registers in the bitset, except sp.
 // Return the number of heapwords pushed.
 int MacroAssembler::push_fp(unsigned int bitset, Register stack) {
   int words_pushed = 0;
   unsigned char regs[32];
-  int count = bitset_to_fregs(bitset, regs);
+  int count = bitset_to_regs(bitset, regs);
   int push_slots = count + (count & 1);
 
   if (count) {
@@ -1045,7 +1032,7 @@ int MacroAssembler::push_fp(unsigned int bitset, Register stack) {
 int MacroAssembler::pop_fp(unsigned int bitset, Register stack) {
   int words_popped = 0;
   unsigned char regs[32];
-  int count = bitset_to_fregs(bitset, regs);
+  int count = bitset_to_regs(bitset, regs);
   int pop_slots = count + (count & 1);
 
   for (int i = count - 1; i >= 0; i--) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -796,7 +796,6 @@ private:
     }
   }
 
-  int bitset_to_fregs(unsigned int bitset, unsigned char* regs);
   int bitset_to_regs(unsigned int bitset, unsigned char* regs);
   Address add_memory_helper(const Address dst);
 


### PR DESCRIPTION
After [JDK-8278337](https://bugs.openjdk.java.net/browse/JDK-8278337), the definition of `bitset_to_fregs` is just same as `bitset_to_regs`.

Hotspot and jdk tier1 passed on the unmatched board. All tests were tested without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278531](https://bugs.openjdk.java.net/browse/JDK-8278531): riscv: Remove duplicate code bitset_to_fregs


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/28.diff">https://git.openjdk.java.net/riscv-port/pull/28.diff</a>

</details>
