### PR TITLE
8278743: riscv: Remove the x4 register saving logic in Java frames

### DIFF
--- a/src/hotspot/cpu/riscv/frame_riscv.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.hpp
@@ -131,7 +131,7 @@
     // Entry frames
     // n.b. these values are determined by the layout defined in
     // stubGenerator for the Java call stub
-    entry_frame_after_call_words                     =  23,
+    entry_frame_after_call_words                     =  22,
     entry_frame_call_wrapper_offset                  = -10,
 
     // we don't need a save area

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -127,19 +127,18 @@ class StubGenerator: public StubCodeGenerator {
   //     [ return_from_Java     ] <--- sp
   //     [ argument word n      ]
   //      ...
-  // -23 [ argument word 1      ]
-  // -22 [ saved x27            ] <--- sp_after_call
-  // -21 [ saved x26            ]
-  // -20 [ saved x25            ]
-  // -19 [ saved x24            ]
-  // -18 [ saved x23            ]
-  // -17 [ saved x22            ]
-  // -16 [ saved x21            ]
-  // -15 [ saved x20            ]
-  // -14 [ saved x19            ]
-  // -13 [ saved x18            ]
-  // -12 [ saved x9             ]
-  // -11 [ thread pointer (x4)  ]
+  // -22 [ argument word 1      ]
+  // -21 [ saved x27            ] <--- sp_after_call
+  // -20 [ saved x26            ]
+  // -19 [ saved x25            ]
+  // -18 [ saved x24            ]
+  // -17 [ saved x23            ]
+  // -16 [ saved x22            ]
+  // -15 [ saved x21            ]
+  // -14 [ saved x20            ]
+  // -13 [ saved x19            ]
+  // -12 [ saved x18            ]
+  // -11 [ saved x9             ]
   // -10 [ call wrapper   (x10) ]
   //  -9 [ result         (x11) ]
   //  -8 [ result type    (x12) ]
@@ -154,21 +153,19 @@ class StubGenerator: public StubCodeGenerator {
 
   // Call stub stack layout word offsets from fp
   enum call_stub_layout {
-    sp_after_call_off  = -22,
+    sp_after_call_off  = -21,
 
-    x27_off            = -22,
-    x26_off            = -21,
-    x25_off            = -20,
-    x24_off            = -19,
-    x23_off            = -18,
-    x22_off            = -17,
-    x21_off            = -16,
-    x20_off            = -15,
-    x19_off            = -14,
-    x18_off            = -13,
-    x9_off             = -12,
-
-    x4_off             = -11,
+    x27_off            = -21,
+    x26_off            = -20,
+    x25_off            = -19,
+    x24_off            = -18,
+    x23_off            = -17,
+    x22_off            = -16,
+    x21_off            = -15,
+    x20_off            = -14,
+    x19_off            = -13,
+    x18_off            = -12,
+    x9_off             = -11,
 
     call_wrapper_off   = -10,
     result_off         = -9,
@@ -214,7 +211,6 @@ class StubGenerator: public StubCodeGenerator {
     const Address x18_save      (fp, x18_off            * wordSize);
 
     const Address x9_save       (fp, x9_off             * wordSize);
-    const Address x4_save       (fp, x4_off             * wordSize);
 
     // stub code
 
@@ -236,7 +232,6 @@ class StubGenerator: public StubCodeGenerator {
     __ sd(c_rarg1, result);
     __ sd(c_rarg0, call_wrapper);
 
-    __ sd(x4, x4_save);
     __ sd(x9, x9_save);
 
     __ sd(x18, x18_save);
@@ -353,7 +348,6 @@ class StubGenerator: public StubCodeGenerator {
     __ ld(x18, x18_save);
 
     __ ld(x9, x9_save);
-    __ ld(x4, x4_save);
 
     __ ld(c_rarg0, call_wrapper);
     __ ld(c_rarg1, result);


### PR DESCRIPTION
Hi team,

x4 is the thread pointer register and would be modified by the kernel. With this respect, we shall not modify or change its value. In the riscv-port repo, we have no other modifications for the x4 register so I would recommend removing the x4 saving logic in java frames. I have verified this change along with other patches under jdk/hotspot full tiers on different boards and qemu.

BTW, due to the logic that can automatically adjust the sp to 16-byte aligned[1], it is safe to change the `sp_after_call_off` to an odd number.

[1] https://github.com/openjdk/riscv-port/blob/riscv-port/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp#L277

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278743](https://bugs.openjdk.java.net/browse/JDK-8278743): riscv: Remove the x4 register saving logic in Java frames


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/29.diff">https://git.openjdk.java.net/riscv-port/pull/29.diff</a>

</details>
