### PR TITLE
8278832: riscv: Inconsistency of Java frame offset definition in jdk.hotspot.agent

### DIFF
--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
@@ -47,12 +47,12 @@ public class RISCV64Frame extends Frame {
   }
 
   // Java frames
-  private static final int LINK_OFFSET                =  0;
-  private static final int RETURN_ADDR_OFFSET         =  1;
-  private static final int SENDER_SP_OFFSET           =  2;
+  private static final int LINK_OFFSET                =  -2;
+  private static final int RETURN_ADDR_OFFSET         =  -1;
+  private static final int SENDER_SP_OFFSET           =   0;
 
   // Interpreter frames
-  private static final int INTERPRETER_FRAME_SENDER_SP_OFFSET = -1;
+  private static final int INTERPRETER_FRAME_SENDER_SP_OFFSET = -3;
   private static final int INTERPRETER_FRAME_LAST_SP_OFFSET   = INTERPRETER_FRAME_SENDER_SP_OFFSET - 1;
   private static final int INTERPRETER_FRAME_METHOD_OFFSET    = INTERPRETER_FRAME_LAST_SP_OFFSET - 1;
   private static       int INTERPRETER_FRAME_MDX_OFFSET;         // Non-core builds only
@@ -66,7 +66,7 @@ public class RISCV64Frame extends Frame {
   private static       int INTERPRETER_FRAME_MONITOR_BLOCK_BOTTOM_OFFSET;
 
   // Entry frames
-  private static       int ENTRY_FRAME_CALL_WRAPPER_OFFSET = -8;
+  private static       int ENTRY_FRAME_CALL_WRAPPER_OFFSET = -10;
 
   // Native frames
   private static final int NATIVE_FRAME_INITIAL_PARAM_OFFSET =  2;


### PR DESCRIPTION
The Java frame definition was refactored in https://github.com/openjdk/jdk-sandbox/commit/db2415748747a0912749bb8fc160a8948021a924 to make Java frame offset the same as C frame. In jdk.hotspot.agent, there is another Java frame definition based on the old Java frame offset, which causes jstack stack walking error. These definitions should also be updated.

Two tests passed after this fixing:
- test/hotspot/jtreg/serviceability/sa/ClhsdbCDSCore.java
- test/hotspot/jtreg/serviceability/sa/ClhsdbFindPC.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278832](https://bugs.openjdk.java.net/browse/JDK-8278832): riscv: Inconsistency of Java frame offset definition in jdk.hotspot.agent


### Reviewers
 * [Yadong Wang](https://openjdk.java.net/census#yadongwang) (@yadongw - Author)
 * [Yanhong Zhu](https://openjdk.java.net/census#yzhu) (@yhzhu20 - Author)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/30/head:pull/30` \
`$ git checkout pull/30`

Update a local copy of the PR: \
`$ git checkout pull/30` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/30/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 30`

View PR using the GUI difftool: \
`$ git pr show -t 30`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/30.diff">https://git.openjdk.java.net/riscv-port/pull/30.diff</a>

</details>
