### PR TITLE
8278833: riscv: Remove the x3 and x4 register saving logic in register savers

### DIFF
--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -332,10 +332,10 @@ static void restore_live_registers_except_r10(StubAssembler* sasm, bool restore_
     __ addi(sp, sp, 32 * wordSize);
   }
 
-  // if the number of popped regs is odd, the reserved slot for alignment will be removed
-  // integer registers except ra(x1) & sp(x2) & gp(x3) & tp(x4) & x10
-  __ pop_reg(RegSet::range(x5, x9), sp);   // pop zr, x5 ~ x9
-  __ pop_reg(RegSet::range(x11, x31), sp); // pop x10 ~ x31, x10 will be loaded to zr
+  // pop integer registers except ra(x1) & sp(x2) & gp(x3) & tp(x4) & x10
+  // there is one reserved slot for alignment on the stack in save_live_registers().
+  __ pop_reg(RegSet::range(x5, x9), sp);   // pop x5 ~ x9 with the reserved slot for alignment
+  __ pop_reg(RegSet::range(x11, x31), sp); // pop x11 ~ x31; x10 will be automatically skipped here
 }
 
 void Runtime1::initialize_pd() {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1118,18 +1118,19 @@ void MacroAssembler::pop_call_clobbered_registers_except(RegSet exclude) {
   pop_reg(RegSet::of(x7) + RegSet::range(x10, x17) + RegSet::range(x28, x31) - exclude, sp);
 }
 
-// Push all the integer registers, except zr(x0) & sp(x2).
+// Push all the integer registers, except zr(x0) & sp(x2) & gp(x3) & tp(x4).
 void MacroAssembler::pusha() {
-  push_reg(0xfffffffa, sp);
+  push_reg(0xffffffe2, sp);
 }
 
+// Pop all the integer registers, except zr(x0) & sp(x2) & gp(x3) & tp(x4).
 void MacroAssembler::popa() {
-  pop_reg(0xfffffffa, sp);
+  pop_reg(0xffffffe2, sp);
 }
 
 void MacroAssembler::push_CPU_state(bool save_vectors, int vector_size_in_bytes) {
-  // integer registers, except zr(x0) & ra(x1) & sp(x2)
-  push_reg(0xfffffff8, sp);
+  // integer registers, except zr(x0) & ra(x1) & sp(x2) & gp(x3) & tp(x4)
+  push_reg(0xffffffe0, sp);
 
   // float registers
   addi(sp, sp, - 32 * wordSize);
@@ -1164,8 +1165,8 @@ void MacroAssembler::pop_CPU_state(bool restore_vectors, int vector_size_in_byte
   }
   addi(sp, sp, 32 * wordSize);
 
-  // integer registers, except zr(x0) & ra(x1) & sp(x2)
-  pop_reg(0xfffffff8, sp);
+  // integer registers, except zr(x0) & ra(x1) & sp(x2) & gp(x3) & tp(x4)
+  pop_reg(0xffffffe0, sp);
 }
 
 static int patch_offset_in_jal(address branch, int64_t offset) {

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -99,7 +99,7 @@ class RegisterSaver {
   // |---f1---|
   // |   ..   |
   // |---f31--|
-  // |---zr---|
+  // |---reserved slot for stack alignment---|
   // |---x5---|
   // |   x6   |
   // |---.. --|
@@ -117,7 +117,7 @@ class RegisterSaver {
 #endif
     return f0_offset;
   }
-  int x0_offset_in_bytes(void) {
+  int reserved_slot_offset_in_bytes(void) {
     return f0_offset_in_bytes() +
            FloatRegisterImpl::max_slots_per_register *
            FloatRegisterImpl::number_of_registers *
@@ -126,7 +126,7 @@ class RegisterSaver {
 
   int reg_offset_in_bytes(Register r) {
     assert (r->encoding() > 4, "ra, sp, gp and tp not saved");
-    return x0_offset_in_bytes() + (r->encoding() - 4 /* x1, x2, x3, x4 */) * wordSize;
+    return reserved_slot_offset_in_bytes() + (r->encoding() - 4 /* x1, x2, x3, x4 */) * wordSize;
   }
 
   int freg_offset_in_bytes(FloatRegister f) {
@@ -134,7 +134,7 @@ class RegisterSaver {
   }
 
   int ra_offset_in_bytes(void) {
-    return x0_offset_in_bytes() +
+    return reserved_slot_offset_in_bytes() +
            (RegisterImpl::number_of_registers - 3) *
            RegisterImpl::max_slots_per_register *
            BytesPerInt;
@@ -190,12 +190,14 @@ OopMap* RegisterSaver::save_live_registers(MacroAssembler* masm, int additional_
     oop_map->set_callee_saved(VMRegImpl::stack2reg(sp_offset_in_slots), r->as_VMReg());
   }
 
-  // ignore zr, ra, sp, gp and tp, being ignored also by push_CPU_state (pushing zr only for stack alignment)
-  sp_offset_in_slots += RegisterImpl::max_slots_per_register;
   step_in_slots = RegisterImpl::max_slots_per_register;
-  for (int i = 5; i < RegisterImpl::number_of_registers; i++, sp_offset_in_slots += step_in_slots) {
+  // skip the slot reserved for alignment, see MacroAssembler::push_reg;
+  // also skip x5 ~ x6 on the stack because they are caller-saved registers.
+  sp_offset_in_slots += RegisterImpl::max_slots_per_register * 3;
+  // besides, we ignore x0 ~ x4 because push_CPU_state won't push them on the stack.
+  for (int i = 7; i < RegisterImpl::number_of_registers; i++, sp_offset_in_slots += step_in_slots) {
     Register r = as_Register(i);
-    if (r != xthread && r != t0 && r != t1) {
+    if (r != xthread) {
       oop_map->set_callee_saved(VMRegImpl::stack2reg(sp_offset_in_slots + additional_frame_slots), r->as_VMReg());
     }
   }


### PR DESCRIPTION
Hi team,

x3 is the global pointer register used to reference global variables in C++ code, generated by linker; and x4 is the thread pointer register and would be modified by the kernel. In the riscv-port repo, we have no other modifications for the x3 & x4 registers so I would recommend removing the x3 & x4 saving logic in register savers. Previously verified along with other patches under full tiers jdk/hotspot on boards, and verified a simple `test/jtreg/hotspot/compiler` after fixing conflicts with [JDK-8278337](https://github.com/openjdk/riscv-port/pull/25).

BTW since we remove both two registers together, sp remains 16-byte aligned without other changes in stack frames.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278833](https://bugs.openjdk.java.net/browse/JDK-8278833): riscv: Remove the x3 and x4 register saving logic in register savers


### Reviewers
 * [Yadong Wang](https://openjdk.java.net/census#yadongwang) (@yadongw - Author) ⚠️ Review applies to bdb5fba36ecdbe051b5e58df3e1a48856e138b3e
 * [Feilong Jiang](https://openjdk.java.net/census#fjiang) (@feilongjiang - Author)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/31.diff">https://git.openjdk.java.net/riscv-port/pull/31.diff</a>

</details>
