### PR TITLE
8278895: riscv: Rename Riscv64 to RISCV64

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -780,8 +780,7 @@ private:
 #endif
   void repne_scan(Register addr, Register value, Register count, Register temp);
 
-  // Return true if an addres is within the 48-bit Riscv64 address
-  // space.
+  // Return true if an address is within the 48-bit RISCV64 address space.
   bool is_valid_riscv64_address(address addr) {
     return ((uintptr_t)addr >> 48) == 0;
   }

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3457,7 +3457,7 @@ operand indOffLN(iRegN reg, immLOffset off)
   %}
 %}
 
-// Riscv64 opto stubs need to write to the pc slot in the thread anchor
+// RISCV64 opto stubs need to write to the pc slot in the thread anchor
 operand thread_anchor_pc(javaThread_RegP reg, immL_pc_off off)
 %{
   constraint(ALLOC_IN_RC(ptr_reg));

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -2197,7 +2197,7 @@ void SharedRuntime::generate_deopt_blob() {
 // Number of stack slots between incoming argument block and the start of
 // a new frame. The PROLOG must add this many slots to the stack. The
 // EPILOG must remove this many slots.
-// Riscv64 needs two words for RA (return address) and FP (frame pointer).
+// RISCV64 needs two words for RA (return address) and FP (frame pointer).
 uint SharedRuntime::in_preserve_stack_slots() {
   return 2 * VMRegImpl::slots_per_word;
 }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -179,6 +179,6 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_threads = _no_of_cores;
   _no_of_sockets = _no_of_cores;
   snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "RISCV64");
-  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "RISCV64%s", _features_string);
+  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "RISCV64 %s", _features_string);
   _initialized = true;
 }

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -179,6 +179,6 @@ void VM_Version::initialize_cpu_information(void) {
   _no_of_threads = _no_of_cores;
   _no_of_sockets = _no_of_cores;
   snprintf(_cpu_name, CPU_TYPE_DESC_BUF_SIZE - 1, "RISCV64");
-  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "RV64%s", _features_string);
+  snprintf(_cpu_desc, CPU_DETAILED_DESC_BUF_SIZE, "RISCV64%s", _features_string);
   _initialized = true;
 }

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/HotSpotAgent.java
@@ -36,7 +36,7 @@ import sun.jvm.hotspot.debugger.MachineDescription;
 import sun.jvm.hotspot.debugger.MachineDescriptionAMD64;
 import sun.jvm.hotspot.debugger.MachineDescriptionPPC64;
 import sun.jvm.hotspot.debugger.MachineDescriptionAArch64;
-import sun.jvm.hotspot.debugger.MachineDescriptionRiscv64;
+import sun.jvm.hotspot.debugger.MachineDescriptionRISCV64;
 import sun.jvm.hotspot.debugger.MachineDescriptionIntelX86;
 import sun.jvm.hotspot.debugger.NoSuchSymbolException;
 import sun.jvm.hotspot.debugger.bsd.BsdDebuggerLocal;
@@ -571,7 +571,7 @@ public class HotSpotAgent {
         } else if (cpu.equals("aarch64")) {
             machDesc = new MachineDescriptionAArch64();
         } else if (cpu.equals("riscv64")) {
-            machDesc = new MachineDescriptionRiscv64();
+            machDesc = new MachineDescriptionRISCV64();
         } else {
           try {
             machDesc = (MachineDescription)

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/MachineDescriptionRISCV64.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/debugger/MachineDescriptionRISCV64.java
@@ -25,7 +25,7 @@
 
 package sun.jvm.hotspot.debugger;
 
-public class MachineDescriptionRiscv64 extends MachineDescriptionTwosComplement implements MachineDescription {
+public class MachineDescriptionRISCV64 extends MachineDescriptionTwosComplement implements MachineDescription {
   public long getAddressSize() {
     return 8;
   }

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
@@ -39,7 +39,7 @@ package compiler.intrinsics.sha.cli;
 
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForOtherCPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedAArch64CPU;
-import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedRiscv64CPU;
+import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedRISCV64CPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedX86CPU;
 import compiler.intrinsics.sha.cli.testcases.UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU;
 
@@ -50,7 +50,7 @@ public class TestUseSHA1IntrinsicsOptionOnUnsupportedCPU {
                         DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION),
                 new GenericTestCaseForUnsupportedAArch64CPU(
                         DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION),
-                new GenericTestCaseForUnsupportedRiscv64CPU(
+                new GenericTestCaseForUnsupportedRISCV64CPU(
                         DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION),
                 new UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU(
                         DigestOptionsBase.USE_SHA1_INTRINSICS_OPTION),

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
@@ -39,7 +39,7 @@ package compiler.intrinsics.sha.cli;
 
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForOtherCPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedAArch64CPU;
-import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedRiscv64CPU;
+import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedRISCV64CPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedX86CPU;
 import compiler.intrinsics.sha.cli.testcases.UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU;
 
@@ -50,7 +50,7 @@ public class TestUseSHA256IntrinsicsOptionOnUnsupportedCPU {
                         DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION),
                 new GenericTestCaseForUnsupportedAArch64CPU(
                         DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION),
-                new GenericTestCaseForUnsupportedRiscv64CPU(
+                new GenericTestCaseForUnsupportedRISCV64CPU(
                         DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION),
                 new UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU(
                         DigestOptionsBase.USE_SHA256_INTRINSICS_OPTION),

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
@@ -39,7 +39,7 @@ package compiler.intrinsics.sha.cli;
 
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForOtherCPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedAArch64CPU;
-import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedRiscv64CPU;
+import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedRISCV64CPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedX86CPU;
 import compiler.intrinsics.sha.cli.testcases.UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU;
 
@@ -50,7 +50,7 @@ public class TestUseSHA512IntrinsicsOptionOnUnsupportedCPU {
                         DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION),
                 new GenericTestCaseForUnsupportedAArch64CPU(
                         DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION),
-                new GenericTestCaseForUnsupportedRiscv64CPU(
+                new GenericTestCaseForUnsupportedRISCV64CPU(
                         DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION),
                 new UseSHAIntrinsicsSpecificTestCaseForUnsupportedCPU(
                         DigestOptionsBase.USE_SHA512_INTRINSICS_OPTION),

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
@@ -39,7 +39,7 @@ package compiler.intrinsics.sha.cli;
 
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForOtherCPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedAArch64CPU;
-import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedRiscv64CPU;
+import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedRISCV64CPU;
 import compiler.intrinsics.sha.cli.testcases.GenericTestCaseForUnsupportedX86CPU;
 import compiler.intrinsics.sha.cli.testcases.UseSHASpecificTestCaseForUnsupportedCPU;
 
@@ -50,7 +50,7 @@ public class TestUseSHAOptionOnUnsupportedCPU {
                         DigestOptionsBase.USE_SHA_OPTION),
                 new GenericTestCaseForUnsupportedAArch64CPU(
                         DigestOptionsBase.USE_SHA_OPTION),
-                new GenericTestCaseForUnsupportedRiscv64CPU(
+                new GenericTestCaseForUnsupportedRISCV64CPU(
                         DigestOptionsBase.USE_SHA_OPTION),
                 new UseSHASpecificTestCaseForUnsupportedCPU(
                         DigestOptionsBase.USE_SHA_OPTION),

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForOtherCPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForOtherCPU.java
@@ -32,7 +32,7 @@ import jdk.test.lib.cli.predicate.OrPredicate;
 
 /**
  * Generic test case for SHA-related options targeted to any CPU except
- * AArch64, Riscv64, PPC, S390x, and X86.
+ * AArch64, RISCV64, PPC, S390x, and X86.
  */
 public class GenericTestCaseForOtherCPU extends
         DigestOptionsBase.TestCase {
@@ -44,10 +44,10 @@ public class GenericTestCaseForOtherCPU extends
     }
 
     public GenericTestCaseForOtherCPU(String optionName, boolean checkUseSHA) {
-        // Execute the test case on any CPU except AArch64, Riscv64, PPC, S390x, and X86.
+        // Execute the test case on any CPU except AArch64, RISCV64, PPC, S390x, and X86.
         super(optionName, new NotPredicate(
                               new OrPredicate(Platform::isAArch64,
-                              new OrPredicate(Platform::isRiscv64,
+                              new OrPredicate(Platform::isRISCV64,
                               new OrPredicate(Platform::isS390x,
                               new OrPredicate(Platform::isPPC,
                               new OrPredicate(Platform::isX64,
@@ -60,7 +60,7 @@ public class GenericTestCaseForOtherCPU extends
     protected void verifyWarnings() throws Throwable {
         String shouldPassMessage = String.format("JVM should start with "
                 + "option '%s' without any warnings", optionName);
-        // Verify that on non-x86, non-Riscv64 and non-AArch64 CPU usage of SHA-related
+        // Verify that on non-x86, non-RISCV64 and non-AArch64 CPU usage of SHA-related
         // options will not cause any warnings.
         CommandLineOptionTest.verifySameJVMStartup(null,
                 new String[] { ".*" + optionName + ".*" }, shouldPassMessage,

--- a/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForUnsupportedRISCV64CPU.java
+++ b/test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForUnsupportedRISCV64CPU.java
@@ -32,20 +32,20 @@ import jdk.test.lib.cli.predicate.AndPredicate;
 import jdk.test.lib.cli.predicate.NotPredicate;
 
 /**
- * Generic test case for SHA-related options targeted to Riscv64 CPUs
+ * Generic test case for SHA-related options targeted to RISCV64 CPUs
  * which don't support instruction required by the tested option.
  */
-public class GenericTestCaseForUnsupportedRiscv64CPU extends
+public class GenericTestCaseForUnsupportedRISCV64CPU extends
         DigestOptionsBase.TestCase {
 
     final private boolean checkUseSHA;
 
-    public GenericTestCaseForUnsupportedRiscv64CPU(String optionName) {
+    public GenericTestCaseForUnsupportedRISCV64CPU(String optionName) {
         this(optionName, true);
     }
 
-    public GenericTestCaseForUnsupportedRiscv64CPU(String optionName, boolean checkUseSHA) {
-        super(optionName, new AndPredicate(Platform::isRiscv64,
+    public GenericTestCaseForUnsupportedRISCV64CPU(String optionName, boolean checkUseSHA) {
+        super(optionName, new AndPredicate(Platform::isRISCV64,
                 new NotPredicate(DigestOptionsBase.getPredicateForOption(
                         optionName))));
 
@@ -97,14 +97,14 @@ public class GenericTestCaseForUnsupportedRiscv64CPU extends
             // using CLI options.
             CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
                     String.format("Option '%s' should be off on unsupported "
-                            + "Riscv64CPU even if set to true directly", optionName),
+                            + "RISCV64CPU even if set to true directly", optionName),
                     DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,
                     CommandLineOptionTest.prepareBooleanFlag(optionName, true));
 
             // Verify that option is disabled when +UseSHA was passed to JVM.
             CommandLineOptionTest.verifyOptionValueForSameVM(optionName, "false",
                     String.format("Option '%s' should be off on unsupported "
-                            + "Riscv64CPU even if %s flag set to JVM",
+                            + "RISCV64CPU even if %s flag set to JVM",
                             optionName, CommandLineOptionTest.prepareBooleanFlag(
                                 DigestOptionsBase.USE_SHA_OPTION, true)),
                     DigestOptionsBase.UNLOCK_DIAGNOSTIC_VM_OPTIONS,

--- a/test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java
+++ b/test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java
@@ -133,7 +133,7 @@ public class CheckForProperDetailStackTrace {
             // It's ok for ARM not to have symbols, because it does not support NMT detail
             // when targeting thumb2. It's also ok for Windows not to have symbols, because
             // they are only available if the symbols file is included with the build.
-            if (Platform.isWindows() || Platform.isARM() || Platform.isRiscv64()) {
+            if (Platform.isWindows() || Platform.isARM() || Platform.isRISCV64()) {
                 return; // we are done
             }
             output.reportDiagnosticSummary();

--- a/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTest.java
+++ b/test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTest.java
@@ -240,7 +240,7 @@ public class ReservedStackTest {
         return Platform.isAix() ||
             (Platform.isLinux() &&
              (Platform.isPPC() || Platform.isS390x() || Platform.isX64() ||
-              Platform.isX86() || Platform.isAArch64() || Platform.isRiscv64())) ||
+              Platform.isX86() || Platform.isAArch64() || Platform.isRISCV64())) ||
             Platform.isOSX();
     }
 

--- a/test/jdk/jdk/jfr/event/os/TestCPUInformation.java
+++ b/test/jdk/jdk/jfr/event/os/TestCPUInformation.java
@@ -52,8 +52,8 @@ public class TestCPUInformation {
             Events.assertField(event, "hwThreads").atLeast(1);
             Events.assertField(event, "cores").atLeast(1);
             Events.assertField(event, "sockets").atLeast(1);
-            Events.assertField(event, "cpu").containsAny("Intel", "AMD", "Unknown x86", "ARM", "PPC", "PowerPC", "AArch64", "Riscv64", "s390");
-            Events.assertField(event, "description").containsAny("Intel", "AMD", "Unknown x86", "ARM", "PPC", "PowerPC", "AArch64", "Riscv64", "s390");
+            Events.assertField(event, "cpu").containsAny("Intel", "AMD", "Unknown x86", "ARM", "PPC", "PowerPC", "AArch64", "RISCV64", "s390");
+            Events.assertField(event, "description").containsAny("Intel", "AMD", "Unknown x86", "ARM", "PPC", "PowerPC", "AArch64", "RISCV64", "s390");
         }
     }
 }

--- a/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
+++ b/test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java
@@ -45,7 +45,7 @@ import java.util.Set;
  */
 public class TestMutuallyExclusivePlatformPredicates {
     private static enum MethodGroup {
-        ARCH("isAArch64", "isARM", "isRiscv64", "isPPC", "isS390x", "isX64", "isX86"),
+        ARCH("isAArch64", "isARM", "isRISCV64", "isPPC", "isS390x", "isX64", "isX86"),
         BITNESS("is32bit", "is64bit"),
         OS("isAix", "isLinux", "isOSX", "isWindows"),
         VM_TYPE("isClient", "isServer", "isMinimal", "isZero", "isEmbedded"),

--- a/test/lib/jdk/test/lib/Platform.java
+++ b/test/lib/jdk/test/lib/Platform.java
@@ -195,7 +195,7 @@ public class Platform {
         return isArch("arm.*");
     }
 
-    public static boolean isRiscv64() {
+    public static boolean isRISCV64() {
         return isArch("riscv64");
     }
 


### PR DESCRIPTION
Rename Riscv64 to RISCV64 for consistence.

The related tests passed on QEMU:

- test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA1IntrinsicsOptionOnUnsupportedCPU.java
- test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA256IntrinsicsOptionOnUnsupportedCPU.java
- test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHA512IntrinsicsOptionOnUnsupportedCPU.java
- test/hotspot/jtreg/compiler/intrinsics/sha/cli/TestUseSHAOptionOnUnsupportedCPU.java
- test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForOtherCPU.java
- test/hotspot/jtreg/compiler/intrinsics/sha/cli/testcases/GenericTestCaseForUnsupportedRISCV64CPU.java
- test/hotspot/jtreg/runtime/NMT/CheckForProperDetailStackTrace.java
- test/hotspot/jtreg/runtime/ReservedStack/ReservedStackTest.java
- test/jdk/jdk/jfr/event/os/TestCPUInformation.java
- test/lib-test/jdk/test/lib/TestMutuallyExclusivePlatformPredicates.java

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278895](https://bugs.openjdk.java.net/browse/JDK-8278895): riscv: Rename Riscv64 to RISCV64


### Reviewers
 * @guotaiping1 (no known github.com user name / role)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Taiping Guo `<guotaiping1@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/33.diff">https://git.openjdk.java.net/riscv-port/pull/33.diff</a>

</details>
