### PR TITLE
8278890: riscv: Missing features string in VM_Version

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.hpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.hpp
@@ -35,13 +35,13 @@
 class VM_Version : public Abstract_VM_Version {
 #ifdef COMPILER2
 private:
-  static void get_c2_processor_features();
+  static void initialize_c2();
 #endif // COMPILER2
 
 protected:
+  static const char* _uarch;
   static uint32_t _initial_vector_length;
-  static void get_processor_features();
-  static void get_cpu_info();
+  static void get_os_cpu_info();
   static uint32_t get_current_vector_length();
 
 public:
@@ -53,14 +53,14 @@ public:
 
   enum Feature_Flag {
 #define CPU_FEATURE_FLAGS(decl)               \
-    decl(I,            "I",            8)     \
-    decl(M,            "M",           12)     \
-    decl(A,            "A",            0)     \
-    decl(F,            "F",            5)     \
-    decl(D,            "D",            3)     \
-    decl(C,            "C",            2)     \
-    decl(V,            "V",           21)     \
-    decl(B,            "B",            1)
+    decl(I,            "i",            8)     \
+    decl(M,            "m",           12)     \
+    decl(A,            "a",            0)     \
+    decl(F,            "f",            5)     \
+    decl(D,            "d",            3)     \
+    decl(C,            "c",            2)     \
+    decl(V,            "v",           21)     \
+    decl(B,            "b",            1)
 
 #define DECLARE_CPU_FEATURE_FLAG(id, name, bit) CPU_##id = (1 << bit),
     CPU_FEATURE_FLAGS(DECLARE_CPU_FEATURE_FLAG)

--- a/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
+++ b/src/hotspot/os_cpu/linux_riscv/vm_version_linux_riscv.cpp
@@ -79,7 +79,7 @@ uint32_t VM_Version::get_current_vector_length() {
   return (uint32_t)read_csr(CSR_VLENB);
 }
 
-void VM_Version::get_cpu_info() {
+void VM_Version::get_os_cpu_info() {
 
   uint64_t auxv = getauxval(AT_HWCAP);
 
@@ -100,4 +100,19 @@ void VM_Version::get_cpu_info() {
       HWCAP_ISA_C |
       HWCAP_ISA_V |
       HWCAP_ISA_B);
+
+  if (FILE *f = fopen("/proc/cpuinfo", "r")) {
+    char buf[512], *p;
+    while (fgets(buf, sizeof (buf), f) != NULL) {
+      if ((p = strchr(buf, ':')) != NULL) {
+        if (strncmp(buf, "uarch", sizeof "uarch" - 1) == 0) {
+          char* uarch = os::strdup(p + 2);
+          uarch[strcspn(uarch, "\n")] = '\0';
+          _uarch = uarch;
+          break;
+        }
+      }
+    }
+    fclose(f);
+  }
 }


### PR DESCRIPTION
The features_string of VM_Version is supposed to be "sifive,u74-mc,rv64imafdc" for the unmatched board, which is made up of "uarch" and "isa" in /proc/cpuinfo.
In contrast, it's "family 6 model 79 stepping 1 microcode 0xb000036, cx8, cmov, fxsr, ht, mmx, 3dnowpref, sse, sse2, sse3, ssse3, sse4.1, sse4.2, popcnt, lzcnt, tsc, tscinvbit, avx, avx2, aes, erms, clmul, bmi1, bmi2, rtm, adx, fma, vzeroupper, clflush" in a x86 platform, and "0x41:0x0:0xd08:2, fp, simd, evtstrm, aes, pmull, sha1, sha256, crc" in aarch64.
After this PR, the following output is displayed when you run this test case `test/jdk/jdk/jfr/event/os/TestCPUInformation.java` on some common riscv platforms:
1. unmatched:
```
Event: jdk.CPUInformation {
  startTime = 15:54:00.844 (2021-12-20)
  cpu = "RISCV64"
  description = "RISCV64 sifive,u74-mc,rv64imafdc"
  sockets = 4
  cores = 4
  hwThreads = 4
}
```
2. D1:
```
Event: jdk.CPUInformation {
  startTime = 17:04:39.520 (2021-12-20)
  cpu = "RISCV64"
  description = "RISCV64 rv64imafdcv"
  sockets = 1
  cores = 1
  hwThreads = 1
}
```

Hotspot and jdk tier1 passed on the unmatched, and all jtreg tests were tested on Qemu without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278890](https://bugs.openjdk.java.net/browse/JDK-8278890): riscv:  Missing features string in VM_Version


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/35.diff">https://git.openjdk.java.net/riscv-port/pull/35.diff</a>

</details>
