### PR TITLE
8278644: riscv: Intrinsify mulAdd

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3059,7 +3059,7 @@ void MacroAssembler::mul_add(Register out, Register in, Register offset,
   li(tmp, unroll);
   blt(len, tmp, L_tail_loop);
   bind(L_unroll);
-  for (unsigned i = 0; i < unroll; i++) {
+  for (int i = 0; i < unroll; i++) {
     sub(in, in, BytesPerInt);
     lwu(t0, Address(in, 0));
     mul(t1, t0, k);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3025,6 +3025,72 @@ void MacroAssembler::compute_match_mask(Register src, Register pattern, Register
   andr(match_mask, match_mask, src);
 }
 
+#ifdef COMPILER2
+// Code for BigInteger::mulAdd instrinsic
+// out     = x10
+// in      = x11
+// offset  = x12  (already out.length-offset)
+// len     = x13
+// k       = x14
+// tmp     = x28
+//
+// pseudo code from java implementation:
+// carry = 0;
+// offset = out.length-offset - 1;
+// for (int j = len - 1; j >= 0; j--) {
+//     product = (in[j] & LONG_MASK) * kLong + (out[offset] & LONG_MASK) + carry;
+//     out[offset--] = (int)product;
+//     carry = product >>> 32;
+// }
+// return (int)carry;
+void MacroAssembler::mul_add(Register out, Register in, Register offset,
+                             Register len, Register k, Register tmp) {
+  Label L_tail_loop, L_unroll, L_end;
+  mv(tmp, out);
+  mv(out, zr);
+  beqz(len, L_end);
+  zero_ext(k, k, 32);
+  slli(t0, offset, LogBytesPerInt);
+  add(offset, tmp, t0);
+  slli(t0, len, LogBytesPerInt);
+  add(in, in, t0);
+
+  const int unroll = 8;
+  li(tmp, unroll);
+  blt(len, tmp, L_tail_loop);
+  bind(L_unroll);
+  for (unsigned i = 0; i < unroll; i++) {
+    sub(in, in, BytesPerInt);
+    lwu(t0, Address(in, 0));
+    mul(t1, t0, k);
+    add(t0, t1, out);
+    sub(offset, offset, BytesPerInt);
+    lwu(t1, Address(offset, 0));
+    add(t0, t0, t1);
+    sw(t0, Address(offset, 0));
+    srli(out, t0, 32);
+  }
+  sub(len, len, tmp);
+  bge(len, tmp, L_unroll);
+
+  bind(L_tail_loop);
+  beqz(len, L_end);
+  sub(in, in, BytesPerInt);
+  lwu(t0, Address(in, 0));
+  mul(t1, t0, k);
+  add(t0, t1, out);
+  sub(offset, offset, BytesPerInt);
+  lwu(t1, Address(offset, 0));
+  add(t0, t0, t1);
+  sw(t0, Address(offset, 0));
+  srli(out, t0, 32);
+  sub(len, len, 1);
+  j(L_tail_loop);
+
+  bind(L_end);
+}
+#endif
+
 // Count bits of trailing zero chars from lsb to msb until first non-zero element.
 // For LL case, one byte for one element, so shift 8 bits once, and for other case,
 // shift 16 bits once.

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -656,6 +656,11 @@ class MacroAssembler: public Assembler {
   void compute_match_mask(Register src, Register pattern, Register match_mask,
                           Register mask1, Register mask2);
 
+#ifdef COMPILER2
+  void mul_add(Register out, Register in, Register offset,
+               Register len, Register k, Register tmp);
+#endif
+
   void inflate_lo32(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);
   void inflate_hi32(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2770,6 +2770,31 @@ class StubGenerator: public StubCodeGenerator {
     StubRoutines::riscv64::_string_indexof_linear_ul = generate_string_indexof_linear(true, false);
   }
 
+#ifdef COMPILER2
+  address generate_mulAdd()
+  {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", "mulAdd");
+
+    address entry = __ pc();
+
+    const Register out     = x10;
+    const Register in      = x11;
+    const Register offset  = x12;
+    const Register len     = x13;
+    const Register k       = x14;
+    const Register tmp     = x28;
+
+    BLOCK_COMMENT("Entry:");
+    __ enter();
+    __ mul_add(out, in, offset, len, k, tmp);
+    __ leave();
+    __ ret();
+
+    return entry;
+  }
+#endif
+
   // Continuation point for throwing of implicit exceptions that are
   // not handled in the current activation. Fabricates an exception
   // oop and initiates normal exception dispatching in this
@@ -2939,6 +2964,12 @@ class StubGenerator: public StubCodeGenerator {
                                                 throw_NullPointerException_at_call));
     // arraycopy stubs used by compilers
     generate_arraycopy_stubs();
+
+#ifdef COMPILER2
+    if (UseMulAddIntrinsic) {
+      StubRoutines::_mulAdd = generate_mulAdd();
+    }
+#endif
 
     generate_compare_long_strings();
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -161,6 +161,10 @@ void VM_Version::get_c2_processor_features() {
   if (FLAG_IS_DEFAULT(AllocatePrefetchStyle)) {
     FLAG_SET_DEFAULT(AllocatePrefetchStyle, 0);
   }
+
+  if (FLAG_IS_DEFAULT(UseMulAddIntrinsic)) {
+    FLAG_SET_DEFAULT(UseMulAddIntrinsic, true);
+  }
 }
 #endif // COMPILER2
 


### PR DESCRIPTION
BigInteger intrinsic: mulAdd intrinsic is missed in current vm. It should be implemented.
The JMH test of mulAdd intrinsic on the matched board shows that the performance can be improved by 0.69%~21.91% when the length of BigInteger changed from 1 to 5000, compared with that of C2.
JMH test: [MyBenchmark.java](https://bugs.openjdk.java.net/secure/attachment/97414/MyBenchmark.java)

Performed full jtreg test with qemu without new failures.

Results list as follows
| length | intrinsic(ops/ms) | no intrinsic(ops/ms) | intrinsic / no intrinsic |
| ------ | ------ | ------ | ------ | 
| 1 | 1643.111 | 1623.814 | 1.18% |
| 2 | 1597.927 | 1585.216 | 0.80% |
| 3 | 1542.249 | 1502.455 | 2.65% |
| 5 | 1533.371 | 1522.837 | 0.69% |
| 10 | 1377.683 | 1361.718 | 1.17% |
| 50 | 925.826 | 844.276 | 9.62% |
| 100 | 638.767 | 576.276 | 10.84% |
| 1000 | 99.870 | 84.796 | 17.78% |
| 2000 | 51.511 | 43.624 | 18.08% |
| 5000 | 18.017 | 14.779 | 21.91% |

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278644](https://bugs.openjdk.java.net/browse/JDK-8278644): riscv: Intrinsify mulAdd


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Taiping Guo `<guotaiping1@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/36.diff">https://git.openjdk.java.net/riscv-port/pull/36.diff</a>

</details>
