### PR TITLE
8279213: riscv: RVB: Add zero/sign extend instructions

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -30,7 +30,7 @@
 #include "asm/register.hpp"
 #include "assembler_riscv.inline.hpp"
 
-#define registerSize 64
+#define XLEN 64
 
 // definitions of various symbolic names for machine registers
 
@@ -1257,6 +1257,7 @@ enum operand_size { int8, int16, int32, uint32, int64 };
   }
 
   #include "assembler_riscv_v.hpp"
+  #include "assembler_riscv_b.hpp"
 
   virtual ~Assembler() {}
 

--- a/src/hotspot/cpu/riscv/assembler_riscv_b.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv_b.hpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ *
+ */
+
+#ifndef CPU_RISCV_ASSEMBLER_RISCV_B_HPP
+#define CPU_RISCV_ASSEMBLER_RISCV_B_HPP
+
+#define INSN(NAME, op, funct3, funct7)                  \
+  void NAME(Register Rd, Register Rs1, Register Rs2) {  \
+    unsigned insn = 0;                                  \
+    patch((address)&insn, 6,  0, op);                   \
+    patch((address)&insn, 14, 12, funct3);              \
+    patch((address)&insn, 31, 25, funct7);              \
+    patch_reg((address)&insn, 7, Rd);                   \
+    patch_reg((address)&insn, 15, Rs1);                 \
+    patch_reg((address)&insn, 20, Rs2);                 \
+    emit(insn);                                         \
+  }
+
+  INSN(add_uw, 0b0111011, 0b000, 0b0000100);
+
+#undef INSN
+
+#define INSN(NAME, op, funct3, funct12)                 \
+  void NAME(Register Rd, Register Rs1) {                \
+    unsigned insn = 0;                                  \
+    patch((address)&insn, 6, 0, op);                    \
+    patch((address)&insn, 14, 12, funct3);              \
+    patch((address)&insn, 31, 20, funct12);             \
+    patch_reg((address)&insn, 7, Rd);                   \
+    patch_reg((address)&insn, 15, Rs1);                 \
+    emit(insn);                                         \
+  }
+
+  INSN(sext_b, 0b0010011, 0b001, 0b011000000100);
+  INSN(sext_h, 0b0010011, 0b001, 0b011000000101);
+  INSN(zext_h, 0b0111011, 0b100, 0b000010000000);
+
+#undef INSN
+
+// RVB pseudo instructions
+// zero extend word
+void zext_w(Register Rd, Register Rs) {
+  add_uw(Rd, Rs, zr);
+}
+
+
+#endif // CPU_RISCV_ASSEMBLER_RISCV_B_HPP

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_arith_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_arith_riscv.cpp
@@ -64,8 +64,7 @@ void LIR_Assembler::arithmetic_idiv(LIR_Code code, LIR_Opr left, LIR_Opr right, 
         if (is_imm_in_range(c - 1, 12, 0)) {
           __ andi(t1, t1, c - 1);
         } else {
-          __ slli(t1, t1, registerSize - shift);
-          __ srli(t1, t1, registerSize - shift);
+          __ zero_extend(t1, t1, shift);
         }
         __ subw(dreg, t1, t0);
       }
@@ -79,8 +78,7 @@ void LIR_Assembler::arithmetic_idiv(LIR_Code code, LIR_Opr left, LIR_Opr right, 
         if (is_imm_in_range(c - 1, 12, 0)) {
           __ andi(t0, t0, c - 1);
         } else {
-          __ slli(t0, t0, registerSize - shift);
-          __ srli(t0, t0, registerSize - shift);
+          __ zero_extend(t0, t0, shift);
         }
         __ addw(dreg, t0, lreg);
         __ sraiw(dreg, dreg, shift);
@@ -203,8 +201,7 @@ void LIR_Assembler::arith_op_double_cpu(LIR_Code code, LIR_Opr left, LIR_Opr rig
           if (is_imm_in_range(c - 1, 12, 0)) {
             __ andi(t0, t0, c - 1);
           } else {
-            __ slli(t0, t0, registerSize - shift);
-            __ srli(t0, t0, registerSize - shift);
+            __ zero_extend(t0, t0, shift);
           }
           __ add(dreg, t0, lreg_lo);
           __ srai(dreg, dreg, shift);
@@ -223,8 +220,7 @@ void LIR_Assembler::arith_op_double_cpu(LIR_Code code, LIR_Opr left, LIR_Opr rig
           if (is_imm_in_range(c - 1, 12, 0)) {
             __ andi(t1, t1, c - 1);
           } else {
-            __ slli(t1, t1, registerSize - shift);
-            __ srli(t1, t1, registerSize - shift);
+            __ zero_extend(t1, t1, shift);
           }
           __ sub(dreg, t1, t0);
         }

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -951,13 +951,13 @@ void LIR_Assembler::emit_opConvert(LIR_OpConvert* op) {
     case Bytecodes::_d2f:
       __ fcvt_s_d(dest->as_float_reg(), src->as_double_reg()); break;
     case Bytecodes::_i2c:
-      __ zero_ext(dest->as_register(), src->as_register(), registerSize - 16); break; // 16: char size
+      __ zero_extend(dest->as_register(), src->as_register(), 16); break;
     case Bytecodes::_i2l:
       __ addw(dest->as_register_lo(), src->as_register(), zr); break;
     case Bytecodes::_i2s:
-      __ sign_ext(dest->as_register(), src->as_register(), registerSize - 16); break; // 16: short size
+      __ sign_extend(dest->as_register(), src->as_register(), 16); break;
     case Bytecodes::_i2b:
-      __ sign_ext(dest->as_register(), src->as_register(), registerSize - 8); break;  // 8: byte size
+      __ sign_extend(dest->as_register(), src->as_register(), 8); break;
     case Bytecodes::_l2i:
       _masm->block_comment("FIXME: This coulde be no-op");
       __ addw(dest->as_register(), src->as_register_lo(), zr); break;

--- a/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_Runtime1_riscv.cpp
@@ -819,8 +819,8 @@ OopMapSet* Runtime1::generate_code_for(StubID id, StubAssembler* sasm) {
           __ sll(arr_size, length, t0);
           int lh_header_size_width = log2i_exact(Klass::_lh_header_size_mask + 1);
           int lh_header_size_msb = Klass::_lh_header_size_shift + lh_header_size_width;
-          __ slli(tmp1, tmp1, registerSize - lh_header_size_msb);
-          __ srli(tmp1, tmp1, registerSize - lh_header_size_width);
+          __ slli(tmp1, tmp1, XLEN - lh_header_size_msb);
+          __ srli(tmp1, tmp1, XLEN - lh_header_size_width);
           __ add(arr_size, arr_size, tmp1);
           __ addi(arr_size, arr_size, MinObjAlignmentInBytesMask); // align up
           __ andi(arr_size, arr_size, ~(uint)MinObjAlignmentInBytesMask);

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -450,10 +450,10 @@ void C2_MacroAssembler::string_indexof(Register haystack, Register needle,
     // convert Latin1 to UTF. eg: 0x0000abcd -> 0x0a0b0c0d
     // We'll have to wait until load completed, but it's still faster than per-character loads+checks
     srli(tmp3, tmp6, BitsPerByte * (wordSize / 2 - needle_chr_size)); // pattern[m-1], eg:0x0000000a
-    slli(ch2, tmp6, registerSize - 24);
-    srli(ch2, ch2, registerSize - 8); // pattern[m-2], 0x0000000b
-    slli(ch1, tmp6, registerSize - 16);
-    srli(ch1, ch1, registerSize - 8); // pattern[m-3], 0x0000000c
+    slli(ch2, tmp6, XLEN - 24);
+    srli(ch2, ch2, XLEN - 8); // pattern[m-2], 0x0000000b
+    slli(ch1, tmp6, XLEN - 16);
+    srli(ch1, ch1, XLEN - 8); // pattern[m-3], 0x0000000c
     andi(tmp6, tmp6, 0xff); // pattern[m-4], 0x0000000d
     slli(ch2, ch2, 16);
     orr(ch2, ch2, ch1); // 0x00000b0c

--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -90,6 +90,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Extend fence.i to fence.i + fence.")                                  \
   product(bool, AvoidUnalignedAccesses, true,                                    \
           "Avoid generating unaligned memory accesses")                          \
-  product(bool, UseRVV, false, EXPERIMENTAL, "Use RVV instructions")
+  product(bool, UseRVV, false, EXPERIMENTAL, "Use RVV instructions")             \
+  product(bool, UseRVB, false, EXPERIMENTAL, "Use RVB instructions")
 
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -67,17 +67,17 @@ void InterpreterMacroAssembler::narrow(Register result) {
   bind(notBool);
   mv(t1, T_BYTE);
   bne(t0, t1, notByte);
-  sign_ext(result, result, registerSize - 8);
+  sign_extend(result, result, 8);
   j(done);
 
   bind(notByte);
   mv(t1, T_CHAR);
   bne(t0, t1, notChar);
-  zero_ext(result, result, registerSize - 16); // turncate upper 48 bits
+  zero_extend(result, result, 16);
   j(done);
 
   bind(notChar);
-  sign_ext(result, result, registerSize - 16); // sign-extend short
+  sign_extend(result, result, 16);
 
   // Nothing to do for T_INT
   bind(done);
@@ -250,8 +250,8 @@ void InterpreterMacroAssembler::get_cache_and_index_and_bytecode_at_bcp(Register
   lwu(bytecode, bytecode);
   membar(MacroAssembler::LoadLoad | MacroAssembler::LoadStore);
   const int shift_count = (1 + byte_no) * BitsPerByte;
-  slli(bytecode, bytecode, registerSize - (shift_count + BitsPerByte));
-  srli(bytecode, bytecode, registerSize - BitsPerByte);
+  slli(bytecode, bytecode, XLEN - (shift_count + BitsPerByte));
+  srli(bytecode, bytecode, XLEN - BitsPerByte);
 }
 
 void InterpreterMacroAssembler::get_cache_entry_pointer_at_bcp(Register cache,

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -683,6 +683,10 @@ void MacroAssembler::sext_w(Register Rd, Register Rs) {
   addiw(Rd, Rs, 0);
 }
 
+void MacroAssembler::zext_b(Register Rd, Register Rs) {
+  andi(Rd, Rs, 0xFF);
+}
+
 void MacroAssembler::seqz(Register Rd, Register Rs) {
   sltiu(Rd, Rs, 1);
 }
@@ -3437,8 +3441,13 @@ void MacroAssembler::zero_extend(Register dst, Register src, int bits) {
       return;
     }
   }
-  slli(dst, src, XLEN - bits);
-  srli(dst, dst, XLEN - bits);
+
+  if (bits == 8) {
+    zext_b(dst, src);
+  } else {
+    slli(dst, src, XLEN - bits);
+    srli(dst, dst, XLEN - bits);
+  }
 }
 
 void MacroAssembler::sign_extend(Register dst, Register src, int bits) {

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1902,7 +1902,7 @@ void MacroAssembler::encode_klass_not_null(Register dst, Register src, Register 
 
   if (((uint64_t)(uintptr_t)CompressedKlassPointers::base() & 0xffffffff) == 0 &&
       CompressedKlassPointers::shift() == 0) {
-    zero_ext(dst, src, 32); // clear upper 32 bits
+    zero_extend(dst, src, 32);
     return;
   }
 
@@ -2219,7 +2219,7 @@ void MacroAssembler::load_reserved(Register addr,
       break;
     case uint32:
       lr_w(t0, addr, acquire);
-      clear_upper_bits(t0, 32);
+      zero_extend(t0, t0, 32);
       break;
     default:
       ShouldNotReachHere();
@@ -2262,7 +2262,7 @@ void MacroAssembler::cmpxchg_narrow_value_helper(Register addr, Register expecte
   } else {
     // size == int16 case
     addi(mask, zr, -1);
-    zero_ext(mask, mask, registerSize - 16);
+    zero_extend(mask, mask, 16);
   }
   sll(mask, mask, shift);
 
@@ -2315,10 +2315,10 @@ void MacroAssembler::cmpxchg_narrow_value(Register addr, Register expected,
     srl(result, tmp, shift);
 
     if (size == int8) {
-      sign_ext(result, result, registerSize - 8);
+      sign_extend(result, result, 8);
     } else {
       // size == int16 case
-      sign_ext(result, result, registerSize - 16);
+      sign_extend(result, result, 16);
     }
   }
 }
@@ -2448,7 +2448,7 @@ ATOMIC_XCHG(xchgalw, amoswap_w, Assembler::aq, Assembler::rl)
 #define ATOMIC_XCHGU(OP1, OP2)                                                       \
 void MacroAssembler::atomic_##OP1(Register prev, Register newv, Register addr) {     \
   atomic_##OP2(prev, newv, addr);                                                    \
-  clear_upper_bits(prev, 32);                                                        \
+  zero_extend(prev, prev, 32);                                                       \
   return;                                                                            \
 }
 
@@ -2827,7 +2827,7 @@ void  MacroAssembler::set_narrow_oop(Register dst, jobject obj) {
   RelocationHolder rspec = oop_Relocation::spec(oop_index);
   code_section()->relocate(inst_mark(), rspec);
   li32(dst, 0xDEADBEEF);
-  clear_upper_bits(dst, 32); // clear upper 32bit, do not sign extend.
+  zero_extend(dst, dst, 32);
 }
 
 void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
@@ -2841,7 +2841,7 @@ void  MacroAssembler::set_narrow_klass(Register dst, Klass* k) {
   code_section()->relocate(inst_mark(), rspec);
   narrowKlass nk = CompressedKlassPointers::encode(k);
   li32(dst, nk);
-  clear_upper_bits(dst, 32); // clear upper 32bit, do not sign extend.
+  zero_extend(dst, dst, 32);
 }
 
 // Maybe emit a call via a trampoline.  If the code cache is small
@@ -3050,7 +3050,7 @@ void MacroAssembler::mul_add(Register out, Register in, Register offset,
   mv(tmp, out);
   mv(out, zr);
   beqz(len, L_end);
-  zero_ext(k, k, 32);
+  zero_extend(k, k, 32);
   slli(t0, offset, LogBytesPerInt);
   add(offset, tmp, t0);
   slli(t0, len, LogBytesPerInt);
@@ -3427,14 +3427,37 @@ void MacroAssembler::zero_memory(Register addr, Register len, Register tmp1) {
   bnez(len, loop);
 }
 
-void MacroAssembler::zero_ext(Register dst, Register src, int clear_bits) {
-  slli(dst, src, clear_bits);
-  srli(dst, dst, clear_bits);
+void MacroAssembler::zero_extend(Register dst, Register src, int bits) {
+  if (UseRVB) {
+    if (bits == 16) {
+      zext_h(dst, src);
+      return;
+    } else if (bits == 32) {
+      zext_w(dst, src);
+      return;
+    }
+  }
+  slli(dst, src, XLEN - bits);
+  srli(dst, dst, XLEN - bits);
 }
 
-void MacroAssembler::sign_ext(Register dst, Register src, int clear_bits) {
-  slli(dst, src, clear_bits);
-  srai(dst, dst, clear_bits);
+void MacroAssembler::sign_extend(Register dst, Register src, int bits) {
+  if (UseRVB) {
+    if (bits == 8) {
+      sext_b(dst, src);
+      return;
+    } else if (bits == 16) {
+      sext_h(dst, src);
+      return;
+    }
+  }
+
+  if (bits == 32) {
+    sext_w(dst, src);
+  } else {
+    slli(dst, src, XLEN - bits);
+    srai(dst, dst, XLEN - bits);
+  }
 }
 
 void MacroAssembler::cmp_l2i(Register dst, Register src1, Register src2, Register tmp)

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -403,6 +403,7 @@ class MacroAssembler: public Assembler {
   void neg(Register Rd, Register Rs);
   void negw(Register Rd, Register Rs);
   void sext_w(Register Rd, Register Rs);
+  void zext_b(Register Rd, Register Rs);
   void seqz(Register Rd, Register Rs);          // set if = zero
   void snez(Register Rd, Register Rs);          // set if != zero
   void sltz(Register Rd, Register Rs);          // set if < zero

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -402,7 +402,7 @@ class MacroAssembler: public Assembler {
   void notr(Register Rd, Register Rs);
   void neg(Register Rd, Register Rs);
   void negw(Register Rd, Register Rs);
-  void sext_w(Register Rd, Register Rs);        // mv Rd[31:0], Rs[31:0]
+  void sext_w(Register Rd, Register Rs);
   void seqz(Register Rd, Register Rs);          // set if = zero
   void snez(Register Rd, Register Rs);          // set if != zero
   void sltz(Register Rd, Register Rs);          // set if < zero
@@ -618,17 +618,6 @@ class MacroAssembler: public Assembler {
 
   #define call_Unimplemented() _call_Unimplemented((address)__PRETTY_FUNCTION__)
 
-  void clear_upper_bits(Register r, unsigned upper_bits) {
-    assert(upper_bits < 64, "bit count to clear must be less than 64");
-
-    int sig_bits = 64 - upper_bits; // significance bits
-    if (sig_bits < 12) {
-      andi(r, r, (1UL << sig_bits) - 1);
-    } else {
-      zero_ext(r, r, upper_bits);
-    }
-  }
-
   // Frame creation and destruction shared between JITs.
   void build_frame(int framesize);
   void remove_frame(int framesize);
@@ -725,13 +714,13 @@ class MacroAssembler: public Assembler {
         sltu(Rt, zr, Rt);
         break;
       case T_CHAR   :
-        zero_ext(Rt, Rt, registerSize - 16);
+        zero_extend(Rt, Rt, 16);
         break;
       case T_BYTE   :
-        sign_ext(Rt, Rt, registerSize - 8);
+        sign_extend(Rt, Rt, 8);
         break;
       case T_SHORT  :
-        sign_ext(Rt, Rt, registerSize - 16);
+        sign_extend(Rt, Rt, 16);
         break;
       case T_INT    :
         addw(Rt, Rt, zr);
@@ -749,8 +738,8 @@ class MacroAssembler: public Assembler {
   void double_compare(Register result, FloatRegister Rs1, FloatRegister Rs2, int unordered_result);
 
   // Zero/Sign-extend
-  void zero_ext(Register dst, Register src, int clear_bits);
-  void sign_ext(Register dst, Register src, int clear_bits);
+  void zero_extend(Register dst, Register src, int bits);
+  void sign_extend(Register dst, Register src, int bits);
 
   // compare src1 and src2 and get -1/0/1 in dst.
   // if [src1 > src2], dst = 1;

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1512,10 +1512,11 @@ uint MachSpillCopyNode::implementation(CodeBuffer *cbuf, PhaseRegAlloc *ra_, boo
     switch (src_lo_rc) {
       case rc_int:
         if (dst_lo_rc == rc_int) {  // gpr --> gpr copy
-          __ mv(as_Register(Matcher::_regEncode[dst_lo]),
-                as_Register(Matcher::_regEncode[src_lo]));
-          if (!is64 && this->ideal_reg() != Op_RegI) // zero extended for narrow oop or klass
-            __ clear_upper_bits(as_Register(Matcher::_regEncode[dst_lo]), 32);
+          if (!is64 && this->ideal_reg() != Op_RegI) { // zero extended for narrow oop or klass
+            __ zero_extend(as_Register(Matcher::_regEncode[dst_lo]), as_Register(Matcher::_regEncode[src_lo]), 32);
+          } else {
+            __ mv(as_Register(Matcher::_regEncode[dst_lo]), as_Register(Matcher::_regEncode[src_lo]));
+          }
         } else if (dst_lo_rc == rc_float) { // gpr --> fpr copy
           if (is64) {
             __ fmv_d_x(as_FloatRegister(Matcher::_regEncode[dst_lo]),
@@ -7863,11 +7864,10 @@ instruct convUI2L_reg_reg(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask)
   match(Set dst (AndL (ConvI2L src) mask));
 
   ins_cost(ALU_COST * 2);
-  format %{ "slli  $dst, $src, 32\t# ui2l\n\t"
-            "srli  $dst, $dst, 32\t# ui2l, #@convUI2L_reg_reg" %}
+  format %{ "zero_extend $dst, $src, 32\t# ui2l, #@convUI2L_reg_reg" %}
 
   ins_encode %{
-    __ zero_ext(as_Register($dst$$reg), as_Register($src$$reg), 32);
+    __ zero_extend(as_Register($dst$$reg), as_Register($src$$reg), 32);
   %}
 
   ins_pipe(ialu_reg_shift);
@@ -8017,15 +8017,11 @@ instruct convL2D_reg_reg(fRegD dst, iRegL src) %{
 instruct convP2I(iRegINoSp dst, iRegP src) %{
   match(Set dst (ConvL2I (CastP2X src)));
 
-  ins_cost(ALU_COST);
-  format %{ "mv  $dst,  $src\t# ptr -> int\n\t"
-            "slli $dst, $dst, 32\n\t"
-            "srli $dst, $dst, 32\t#@convP2I"
-  %}
+  ins_cost(ALU_COST * 2);
+  format %{ "zero_extend $dst, $src, 32\t# ptr -> int, #@convP2I" %}
 
   ins_encode %{
-    __ mv($dst$$Register, $src$$Register);
-    __ clear_upper_bits($dst$$Register, 32);
+    __ zero_extend($dst$$Register, $src$$Register, 32);
   %}
 
   ins_pipe(ialu_reg);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -1559,8 +1559,8 @@ class StubGenerator: public StubCodeGenerator {
     __ bgtu(temp, t0, L_failed);
 
     // Have to clean up high 32 bits of 'src_pos' and 'dst_pos'.
-    __ clear_upper_bits(src_pos, 32);
-    __ clear_upper_bits(dst_pos, 32);
+    __ zero_extend(src_pos, src_pos, 32);
+    __ zero_extend(dst_pos, dst_pos, 32);
 
     BLOCK_COMMENT("arraycopy_range_checks done");
   }
@@ -1774,8 +1774,8 @@ class StubGenerator: public StubCodeGenerator {
     // Get array_header_in_bytes()
     int lh_header_size_width = log2i_exact(Klass::_lh_header_size_mask + 1);
     int lh_header_size_msb = Klass::_lh_header_size_shift + lh_header_size_width;
-    __ slli(t0_offset, lh, registerSize - lh_header_size_msb);          // left shift to remove 24 ~ 32;
-    __ srli(t0_offset, t0_offset, registerSize - lh_header_size_width); // array_offset
+    __ slli(t0_offset, lh, XLEN - lh_header_size_msb);          // left shift to remove 24 ~ 32;
+    __ srli(t0_offset, t0_offset, XLEN - lh_header_size_width); // array_offset
 
     __ add(src, src, t0_offset);           // src array offset
     __ add(dst, dst, t0_offset);           // dst array offset

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -367,7 +367,7 @@ address TemplateInterpreterGenerator::generate_ArrayIndexOutOfBounds_handler() {
   // setup parameters
 
   // convention: expect aberrant index in register x11
-  __ zero_ext(c_rarg2, x11, 32);
+  __ zero_extend(c_rarg2, x11, 32);
   // convention: expect array in register x13
   __ mv(c_rarg1, x13);
   __ call_VM(noreg,

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -484,8 +484,8 @@ void TemplateTable::condy_helper(Label& Done)
   __ add(off, obj, off);
   const Address field(off, 0); // base + R---->base + offset
 
-  __ slli(flags, flags, registerSize - (ConstantPoolCacheEntry::tos_state_shift + ConstantPoolCacheEntry::tos_state_bits));
-  __ srli(flags, flags, registerSize - ConstantPoolCacheEntry::tos_state_bits); // (1 << 5) - 4 --> 28~31==> flags:0~3
+  __ slli(flags, flags, XLEN - (ConstantPoolCacheEntry::tos_state_shift + ConstantPoolCacheEntry::tos_state_bits));
+  __ srli(flags, flags, XLEN - ConstantPoolCacheEntry::tos_state_bits); // (1 << 5) - 4 --> 28~31==> flags:0~3
 
   switch (bytecode()) {
     case Bytecodes::_ldc:   // fall through
@@ -1571,7 +1571,7 @@ void TemplateTable::wide_iinc()
   transition(vtos, vtos);
   __ lwu(x11, at_bcp(2)); // get constant and index
   __ grev16wu(x11, x11); // reverse bytes in half-word (32bit) and zero-extend
-  __ zero_ext(x12, x11, 48);
+  __ zero_extend(x12, x11, 16);
   __ neg(x12, x12);
   __ slli(x11, x11, 32);
   __ srai(x11, x11, 48);
@@ -1630,7 +1630,7 @@ void TemplateTable::convert()
   // Conversion
   switch (bytecode()) {
     case Bytecodes::_i2l:
-      __ sign_ext(x10, x10, registerSize - 32);
+      __ sign_extend(x10, x10, 32);
       break;
     case Bytecodes::_i2f:
       __ fcvt_s_w(f10, x10);
@@ -1639,13 +1639,13 @@ void TemplateTable::convert()
       __ fcvt_d_w(f10, x10);
       break;
     case Bytecodes::_i2b:
-      __ sign_ext(x10, x10, registerSize - 8);
+      __ sign_extend(x10, x10, 8);
       break;
     case Bytecodes::_i2c:
-      __ zero_ext(x10, x10, registerSize - 16);
+      __ zero_extend(x10, x10, 16);
       break;
     case Bytecodes::_i2s:
-      __ sign_ext(x10, x10, registerSize - 16);
+      __ sign_extend(x10, x10, 16);
       break;
     case Bytecodes::_l2i:
       __ addw(x10, x10, zr);
@@ -2445,9 +2445,9 @@ void TemplateTable::getfield_or_static(int byte_no, bool is_static, RewriteContr
   Label Done, notByte, notBool, notInt, notShort, notChar,
               notLong, notFloat, notObj, notDouble;
 
-  __ slli(flags, raw_flags, registerSize - (ConstantPoolCacheEntry::tos_state_shift +
-                                            ConstantPoolCacheEntry::tos_state_bits));
-  __ srli(flags, flags, registerSize - ConstantPoolCacheEntry::tos_state_bits);
+  __ slli(flags, raw_flags, XLEN - (ConstantPoolCacheEntry::tos_state_shift +
+                                    ConstantPoolCacheEntry::tos_state_bits));
+  __ srli(flags, flags, XLEN - ConstantPoolCacheEntry::tos_state_bits);
 
   assert(btos == 0, "change code, btos != 0");
   __ bnez(flags, notByte);
@@ -2680,9 +2680,9 @@ void TemplateTable::putfield_or_static(int byte_no, bool is_static, RewriteContr
   Label notByte, notBool, notInt, notShort, notChar,
         notLong, notFloat, notObj, notDouble;
 
-  __ slli(flags, flags, registerSize - (ConstantPoolCacheEntry::tos_state_shift +
-                                        ConstantPoolCacheEntry::tos_state_bits));
-  __ srli(flags, flags, registerSize - ConstantPoolCacheEntry::tos_state_bits);
+  __ slli(flags, flags, XLEN - (ConstantPoolCacheEntry::tos_state_shift +
+                                ConstantPoolCacheEntry::tos_state_bits));
+  __ srli(flags, flags, XLEN - ConstantPoolCacheEntry::tos_state_bits);
 
   assert(btos == 0, "change code, btos != 0");
   __ bnez(flags, notByte);
@@ -3231,8 +3231,8 @@ void TemplateTable::prepare_invoke(int byte_no,
   }
 
   // compute return type
-  __ slli(t1, flags, registerSize - (ConstantPoolCacheEntry::tos_state_shift + ConstantPoolCacheEntry::tos_state_bits));
-  __ srli(t1, t1, registerSize - ConstantPoolCacheEntry::tos_state_bits); // (1 << 5) - 4 --> 28~31==> t1:0~3
+  __ slli(t1, flags, XLEN - (ConstantPoolCacheEntry::tos_state_shift + ConstantPoolCacheEntry::tos_state_bits));
+  __ srli(t1, t1, XLEN - ConstantPoolCacheEntry::tos_state_bits); // (1 << 5) - 4 --> 28~31==> t1:0~3
 
   // load return address
   {

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -116,6 +116,11 @@ void VM_Version::initialize() {
     }
   }
 
+  if (UseRVB && !(_features & CPU_B)) {
+    warning("RVB is not supported on this CPU");
+    FLAG_SET_DEFAULT(UseRVB, false);
+  }
+
   if (FLAG_IS_DEFAULT(AvoidUnalignedAccesses)) {
     FLAG_SET_DEFAULT(AvoidUnalignedAccesses, true);
   }


### PR DESCRIPTION
The bit-manipulation (bitmanip) extension collection is comprised of several component extensions to the base RISC-V architecture that are intended to provide some combination of code size reduction, performance improvement, and energy reduction.

The RISC-V BitManipulation Extension (RVB) has released spec v1.0.0 for public review, which is stable enough to support in RISC-V backend.

The latest spec can be obtained from https://github.com/riscv/riscv-bitmanip/releases/tag/1.0.0.

This PR implements Add unsigned word instruction `add.uw` and sign- and zero-extension insturctions: `sext.b`, `sext.h` and `zext.h` 

hotspot and jdk tier1 tests on QEMU with `-XX:+UseRVB` are passed.
> Since the current CPU feature detection cannot detect features on QEMU, we force RVB to be enabled on QEMU to run tests.

Assembly code comparison when UseRVB is enabled/disabled:

command:
```
jdk/bin/java -XX:+UnlockDiagnosticVMOptions -XX:+UseRVB -XX:+PrintInterpreter -version
```
output:
  ```
  result handlers for native calls 64 bytes
  ----------------------------------------------------
  snez        a0, a0
  ret
  zext.h      a0, a0
  ret
  sext.b      a0, a0
  ret
  sext.h      a0, a0
  ret
  addw        a0, a0, zero
  ret
  ret
  ret
  ret
  ret
  ld          a0, 8(s0)
  ret
  ----------------------------------------------------
  ```

command:
```
jdk/bin/java -XX:+UnlockDiagnosticVMOptions -XX:-UseRVB -XX:+PrintInterpreter -version
```
output:
```
result handlers for native calls 128 bytes
----------------------------------------------------
snez        a0, a0
ret
slli        a0, a0, 0x30
srli        a0, a0, 0x30
ret
slli        a0, a0, 0x38
srai        a0, a0, 0x38
ret
slli        a0, a0, 0x30
srai        a0, a0, 0x30
ret
addw        a0, a0, zero
ret
ret
ret
ret
ret
ld          a0, 8(s0)
ret
nop
unimp
...
----------------------------------------------------
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279213](https://bugs.openjdk.java.net/browse/JDK-8279213): riscv: RVB: Add zero/sign extend instructions


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/37.diff">https://git.openjdk.java.net/riscv-port/pull/37.diff</a>

</details>
