### PR TITLE
8279292: riscv: Intrinsify multiplyToLen and squareToLen

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1669,7 +1669,7 @@ void MacroAssembler::movoop(Register dst, jobject obj, bool immediate) {
   // ordered with respected to oop access.
   // Using immediate literals would necessitate fence.i.
   if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL || !immediate) {
-    address dummy = address(uintptr_t(pc()) & -wordSize); // A nearby    address
+    address dummy = address(uintptr_t(pc()) & -wordSize); // A nearby aligned address
     ld_constant(dst, Address(dummy, rspec));
   } else
     mv(dst, Address((address)obj, rspec));

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1669,7 +1669,7 @@ void MacroAssembler::movoop(Register dst, jobject obj, bool immediate) {
   // ordered with respected to oop access.
   // Using immediate literals would necessitate fence.i.
   if (BarrierSet::barrier_set()->barrier_set_nmethod() != NULL || !immediate) {
-    address dummy = address(uintptr_t(pc()) & -wordSize); // A nearby aligned address
+    address dummy = address(uintptr_t(pc()) & -wordSize); // A nearby    address
     ld_constant(dst, Address(dummy, rspec));
   } else
     mv(dst, Address((address)obj, rspec));
@@ -3431,8 +3431,8 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen, Register y, Regi
   add(t0, z, t0);
   sw(carry, Address(t0, 0));
 
-  Label L_second_loop_unaliged;
-  bind(L_second_loop_unaliged);
+  Label L_second_loop_unaligned;
+  bind(L_second_loop_unaligned);
   mv(carry, zr);
   mv(jdx, ylen);
   sub(xstart, xstart, 1);
@@ -3472,7 +3472,7 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen, Register y, Regi
   add(t0, z, t0);
   sw(carry, Address(t0, 0));
 
-  j(L_second_loop_unaliged);
+  j(L_second_loop_unaligned);
 
   bind(L_multiply_64_x_64_loop);
   multiply_64_x_64_loop(x, xstart, x_xstart, y, y_idx, z, carry, product, idx, kdx);

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -649,6 +649,30 @@ class MacroAssembler: public Assembler {
 #ifdef COMPILER2
   void mul_add(Register out, Register in, Register offset,
                Register len, Register k, Register tmp);
+  void cad(Register dst, Register src1, Register src2, Register carry);
+  void cadc(Register dst, Register src1, Register src2, Register carry);
+  void adc(Register dst, Register src1, Register src2, Register carry);
+  void add2_with_carry(Register final_dest_hi, Register dest_hi, Register dest_lo,
+                       Register src1, Register src2, Register carry);
+  void ror(Register dst, Register src, uint32_t imm, Register tmp = t0);
+  void multiply_32_x_32_loop(Register x, Register xstart, Register x_xstart,
+                             Register y, Register y_idx, Register z,
+                             Register carry, Register product,
+                             Register idx, Register kdx);
+  void multiply_64_x_64_loop(Register x, Register xstart, Register x_xstart,
+                             Register y, Register y_idx, Register z,
+                             Register carry, Register product,
+                             Register idx, Register kdx);
+  void multiply_128_x_128_loop(Register y, Register z,
+                               Register carry, Register carry2,
+                               Register idx, Register jdx,
+                               Register yz_idx1, Register yz_idx2,
+                               Register tmp, Register tmp3, Register tmp4,
+                               Register tmp6, Register product_hi);
+  void multiply_to_len(Register x, Register xlen, Register y, Register ylen,
+                       Register z, Register zlen,
+                       Register tmp1, Register tmp2, Register tmp3, Register tmp4,
+                       Register tmp5, Register tmp6, Register product_hi);
 #endif
 
   void inflate_lo32(Register Rd, Register Rs, Register Rtmp1 = t0, Register Rtmp2 = t1);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2793,6 +2793,82 @@ class StubGenerator: public StubCodeGenerator {
 
     return entry;
   }
+
+  /**
+   *  Arguments:
+   *
+   *  Input:
+   *    c_rarg0   - x address
+   *    c_rarg1   - x length
+   *    c_rarg2   - y address
+   *    c_rarg3   - y length
+   *    c_rarg4   - z address
+   *    c_rarg5   - z length
+   */
+  address generate_multiplyToLen()
+  {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", "multiplyToLen");
+    address entry = __ pc();
+
+    const Register x     = x10;
+    const Register xlen  = x11;
+    const Register y     = x12;
+    const Register ylen  = x13;
+    const Register z     = x14;
+    const Register zlen  = x15;
+
+    const Register tmp1  = x16;
+    const Register tmp2  = x17;
+    const Register tmp3  = x7;
+    const Register tmp4  = x28;
+    const Register tmp5  = x29;
+    const Register tmp6  = x30;
+    const Register tmp7  = x31;
+
+    BLOCK_COMMENT("Entry:");
+    __ enter(); // required for proper stackwalking of RuntimeStub frame
+    __ multiply_to_len(x, xlen, y, ylen, z, zlen, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
+    __ leave(); // required for proper stackwalking of RuntimeStub frame
+    __ ret();
+
+    return entry;
+  }
+
+  address generate_squareToLen()
+  {
+    // squareToLen algorithm for sizes 1..127 described in java code works
+    // faster than multiply_to_len on some CPUs and slower on others, but
+    // multiply_to_len shows a bit better overall results
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this, "StubRoutines", "squareToLen");
+    address entry = __ pc();
+
+    const Register x     = x10;
+    const Register xlen  = x11;
+    const Register z     = x12;
+    const Register zlen  = x13;
+    const Register y     = x14; // == x
+    const Register ylen  = x15; // == xlen
+
+    const Register tmp1  = x16;
+    const Register tmp2  = x17;
+    const Register tmp3  = x7;
+    const Register tmp4  = x28;
+    const Register tmp5  = x29;
+    const Register tmp6  = x30;
+    const Register tmp7  = x31;
+
+    BLOCK_COMMENT("Entry:");
+    __ enter();
+    __ mv(y, x);
+    __ mv(ylen, xlen);
+    __ multiply_to_len(x, xlen, y, ylen, z, zlen, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7);
+    __ leave();
+    __ ret();
+
+    return entry;
+  }
 #endif
 
   // Continuation point for throwing of implicit exceptions that are
@@ -2968,6 +3044,14 @@ class StubGenerator: public StubCodeGenerator {
 #ifdef COMPILER2
     if (UseMulAddIntrinsic) {
       StubRoutines::_mulAdd = generate_mulAdd();
+    }
+
+    if (UseMultiplyToLenIntrinsic) {
+      StubRoutines::_multiplyToLen = generate_multiplyToLen();
+    }
+
+    if (UseSquareToLenIntrinsic) {
+      StubRoutines::_squareToLen = generate_squareToLen();
     }
 #endif
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2837,9 +2837,6 @@ class StubGenerator: public StubCodeGenerator {
 
   address generate_squareToLen()
   {
-    // squareToLen algorithm for sizes 1..127 described in java code works
-    // faster than multiply_to_len on some CPUs and slower on others, but
-    // multiply_to_len shows a bit better overall results
     __ align(CodeEntryAlignment);
     StubCodeMark mark(this, "StubRoutines", "squareToLen");
     address entry = __ pc();

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -183,6 +183,14 @@ void VM_Version::c2_initialize() {
   if (FLAG_IS_DEFAULT(UseMulAddIntrinsic)) {
     FLAG_SET_DEFAULT(UseMulAddIntrinsic, true);
   }
+
+  if (FLAG_IS_DEFAULT(UseMultiplyToLenIntrinsic)) {
+    FLAG_SET_DEFAULT(UseMultiplyToLenIntrinsic, true);
+  }
+
+  if (FLAG_IS_DEFAULT(UseSquareToLenIntrinsic)) {
+    FLAG_SET_DEFAULT(UseSquareToLenIntrinsic, true);
+  }
 }
 #endif // COMPILER2
 


### PR DESCRIPTION
BigInteger intrinsic: MultiplyToLen and SquareToLen intrinsic are missed in current vm. They should be implemented.
The JMH tests show that the MultiplyToLen intrinsic improve the performance by up to 2x ~ 3x and the SquareToLen intrinsic improve the performance by up to 1.8x ~ 2x when the length of BigInteger changed from 1 to 5000, compared with that of C2.

Full jtreg tests on qemu and hotspot/jdk tier1 test on Unmathced are passed without new failures.

JMH tests and results on D1 and Unmatched list as follows:
[MyBenchmark.txt](https://github.com/openjdk/riscv-port/files/7779255/MyBenchmark.txt)

[squareToLen_unmatched.txt](https://github.com/openjdk/riscv-port/files/7779247/squareToLen_unmatched.txt)
[squareToLen_d1.txt](https://github.com/openjdk/riscv-port/files/7779248/squareToLen_d1.txt)
[multiplyToLen_unmatched.txt](https://github.com/openjdk/riscv-port/files/7779249/multiplyToLen_unmatched.txt)
[multiplyToLen_d1.txt](https://github.com/openjdk/riscv-port/files/7779250/multiplyToLen_d1.txt)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279292](https://bugs.openjdk.java.net/browse/JDK-8279292): riscv: Intrinsify multiplyToLen and squareToLen


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Contributors
 * Taiping Guo `<guotaiping1@huawei.com>`

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/38.diff">https://git.openjdk.java.net/riscv-port/pull/38.diff</a>

</details>
