### PR TITLE
8279344: riscv: RVB: Add bitwise rotation instructions

### DIFF
--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it

--- a/make/hotspot/gensrc/GensrcAdlc.gmk
+++ b/make/hotspot/gensrc/GensrcAdlc.gmk
@@ -149,6 +149,7 @@ ifeq ($(call check-jvm-feature, compiler2), true)
   ifeq ($(HOTSPOT_TARGET_CPU_ARCH), riscv)
     AD_SRC_FILES += $(call uniq, $(wildcard $(foreach d, $(AD_SRC_ROOTS), \
         $d/cpu/$(HOTSPOT_TARGET_CPU_ARCH)/$(HOTSPOT_TARGET_CPU_ARCH)_v.ad \
+        $d/cpu/$(HOTSPOT_TARGET_CPU_ARCH)/$(HOTSPOT_TARGET_CPU_ARCH)_b.ad \
     )))
   endif
 

--- a/src/hotspot/cpu/riscv/assembler_riscv_b.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv_b.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2021, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/assembler_riscv_b.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv_b.hpp
@@ -39,6 +39,10 @@
   }
 
   INSN(add_uw, 0b0111011, 0b000, 0b0000100);
+  INSN(rol,    0b0110011, 0b001, 0b0110000);
+  INSN(rolw,   0b0111011, 0b001, 0b0110000);
+  INSN(ror,    0b0110011, 0b101, 0b0110000);
+  INSN(rorw,   0b0111011, 0b101, 0b0110000);
 
 #undef INSN
 
@@ -56,6 +60,40 @@
   INSN(sext_b, 0b0010011, 0b001, 0b011000000100);
   INSN(sext_h, 0b0010011, 0b001, 0b011000000101);
   INSN(zext_h, 0b0111011, 0b100, 0b000010000000);
+
+#undef INSN
+
+#define INSN(NAME, op, funct3, funct6)                  \
+  void NAME(Register Rd, Register Rs1, unsigned shamt) {\
+    guarantee(shamt <= 0x3f, "Shamt is invalid");       \
+    unsigned insn = 0;                                  \
+    patch((address)&insn, 6, 0, op);                    \
+    patch((address)&insn, 14, 12, funct3);              \
+    patch((address)&insn, 25, 20, shamt);               \
+    patch((address)&insn, 31, 26, funct6);              \
+    patch_reg((address)&insn, 7, Rd);                   \
+    patch_reg((address)&insn, 15, Rs1);                 \
+    emit(insn);                                         \
+  }
+
+  INSN(rori, 0b0010011, 0b101, 0b011000);
+
+#undef INSN
+
+#define INSN(NAME, op, funct3, funct7)                  \
+  void NAME(Register Rd, Register Rs1, unsigned shamt){ \
+    guarantee(shamt <= 0x1f, "Shamt is invalid");       \
+    unsigned insn = 0;                                  \
+    patch((address)&insn, 6, 0, op);                    \
+    patch((address)&insn, 14, 12, funct3);              \
+    patch((address)&insn, 24, 20, shamt);               \
+    patch((address)&insn, 31, 25, funct7);              \
+    patch_reg((address)&insn, 7, Rd);                   \
+    patch_reg((address)&insn, 15, Rs1);                 \
+    emit(insn);                                         \
+  }
+
+  INSN(roriw, 0b0011011, 0b101, 0b0110000);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -654,7 +654,7 @@ class MacroAssembler: public Assembler {
   void adc(Register dst, Register src1, Register src2, Register carry);
   void add2_with_carry(Register final_dest_hi, Register dest_hi, Register dest_lo,
                        Register src1, Register src2, Register carry);
-  void ror(Register dst, Register src, uint32_t imm, Register tmp = t0);
+  void ror_imm(Register dst, Register src, uint32_t shift, Register tmp = t0);
   void multiply_32_x_32_loop(Register x, Register xstart, Register x_xstart,
                              Register y, Register y_idx, Register z,
                              Register carry, Register product,

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1,7 +1,7 @@
 //
 // Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
 // Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
-// Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+// Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2722,11 +2722,47 @@ operand immI_le_4()
   interface(CONST_INTER);
 %}
 
+operand immI_16()
+%{
+  predicate(n->get_int() == 16);
+  match(ConI);
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+operand immI_24()
+%{
+  predicate(n->get_int() == 24);
+  match(ConI);
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 operand immI_31()
 %{
   predicate(n->get_int() == 31);
   match(ConI);
 
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+operand immI_48()
+%{
+  predicate(n->get_int() == 48);
+  match(ConI);
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+operand immI_56()
+%{
+  predicate(n->get_int() == 56);
+  match(ConI);
   op_cost(0);
   format %{ %}
   interface(CONST_INTER);
@@ -2849,6 +2885,26 @@ operand immByteMapBase()
              ((CardTableBarrierSet*)(BarrierSet::barrier_set()))->card_table()->byte_map_base());
   match(ConP);
 
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+// Int Immediate: low 16-bit mask
+operand immI_16bits()
+%{
+  predicate(n->get_int() == 0xFFFFL);
+  match(ConI);
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+// Long Immediate: low 16-bit mask
+operand immL_16bits()
+%{
+  predicate(n->get_long() == 0xFFFFL);
+  match(ConL);
   op_cost(0);
   format %{ %}
   interface(CONST_INTER);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -2750,24 +2750,6 @@ operand immI_31()
   interface(CONST_INTER);
 %}
 
-operand immI_48()
-%{
-  predicate(n->get_int() == 48);
-  match(ConI);
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-operand immI_56()
-%{
-  predicate(n->get_int() == 56);
-  match(ConI);
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
 operand immI_63()
 %{
   predicate(n->get_int() == 63);
@@ -2893,18 +2875,8 @@ operand immByteMapBase()
 // Int Immediate: low 16-bit mask
 operand immI_16bits()
 %{
-  predicate(n->get_int() == 0xFFFFL);
+  predicate(n->get_int() == 0xFFFF);
   match(ConI);
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-// Long Immediate: low 16-bit mask
-operand immL_16bits()
-%{
-  predicate(n->get_long() == 0xFFFFL);
-  match(ConL);
   op_cost(0);
   format %{ %}
   interface(CONST_INTER);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -7885,14 +7885,13 @@ instruct convL2I_reg(iRegINoSp dst, iRegL src) %{
   ins_pipe(ialu_reg);
 %}
 
-// unsigned int to long (Zero-extend)
-// this pattern occurs in bigmath arithmetic
-instruct convUI2L_reg_reg(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask)
+// int to unsigned long (Zero-extend)
+instruct convI2UL_reg_reg(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask)
 %{
   match(Set dst (AndL (ConvI2L src) mask));
 
   ins_cost(ALU_COST * 2);
-  format %{ "zero_extend $dst, $src, 32\t# ui2l, #@convUI2L_reg_reg" %}
+  format %{ "zero_extend $dst, $src, 32\t# i2ul, #@convI2UL_reg_reg" %}
 
   ins_encode %{
     __ zero_extend(as_Register($dst$$reg), as_Register($src$$reg), 32);

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
-// Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+// Copyright (c) 2022, Huawei Technologies Co., Ltd. All rights reserved.
 // DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 //
 // This code is free software; you can redistribute it and/or modify it

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -1,0 +1,296 @@
+//
+// Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+// Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+// DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+//
+// This code is free software; you can redistribute it and/or modify it
+// under the terms of the GNU General Public License version 2 only, as
+// published by the Free Software Foundation.
+//
+// This code is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+// FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+// version 2 for more details (a copy is included in the LICENSE file that
+// accompanied this code).
+//
+// You should have received a copy of the GNU General Public License version
+// 2 along with this work; if not, write to the Free Software Foundation,
+// Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+//
+// Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+// or visit www.oracle.com if you need additional information or have any
+// questions.
+//
+//
+
+// RISCV Bit-Manipulation Extension Architecture Description File
+
+instruct rorI_imm_rvb(iRegINoSp dst, iRegI src, immI shift) %{
+  predicate(UseRVB);
+  match(Set dst (RotateRight src shift));
+
+  format %{ "roriw    $dst, $src, ($shift & 0x1f)\t#@rorI_imm_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ roriw(as_Register($dst$$reg), as_Register($src$$reg), $shift$$constant & 0x1f);
+  %}
+
+  ins_pipe(ialu_reg_shift);
+%}
+
+instruct rorL_imm_rvb(iRegLNoSp dst, iRegL src, immI shift) %{
+  predicate(UseRVB);
+  match(Set dst (RotateRight src shift));
+
+  format %{ "rori    $dst, $src, ($shift & 0x3f)\t#@rorL_imm_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ rori(as_Register($dst$$reg), as_Register($src$$reg), $shift$$constant & 0x3f);
+  %}
+
+  ins_pipe(ialu_reg_shift);
+%}
+
+instruct rorI_reg_rvb(iRegINoSp dst, iRegI src, iRegI shift) %{
+  predicate(UseRVB);
+  match(Set dst (RotateRight src shift));
+
+  format %{ "rorw    $dst, $src, $shift\t#@rorI_reg_rvb" %}
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ rorw(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
+  %}
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct rorL_reg_rvb(iRegLNoSp dst, iRegL src, iRegI shift) %{
+  predicate(UseRVB);
+  match(Set dst (RotateRight src shift));
+
+  format %{ "ror    $dst, $src, $shift\t#@rorL_reg_rvb" %}
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ ror(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
+  %}
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct rolI_reg_rvb(iRegINoSp dst, iRegI src, iRegI shift) %{
+  predicate(UseRVB);
+  match(Set dst (RotateLeft src shift));
+
+  format %{ "rolw    $dst, $src, $shift\t#@rolI_reg_rvb" %}
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ rolw(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
+  %}
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct rolL_reg_rvb(iRegLNoSp dst, iRegL src, iRegI shift) %{
+  predicate(UseRVB);
+  match(Set dst (RotateLeft src shift));
+
+  format %{ "rol    $dst, $src, $shift\t#@rolL_reg_rvb" %}
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ rol(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
+  %}
+  ins_pipe(ialu_reg_reg);
+%}
+
+// unsigned int to long (zero extend)
+// this pattern occurs in bigmath arithmetic
+instruct convUI2L_reg_reg_rvb(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %{
+  predicate(UseRVB);
+  match(Set dst (AndL (ConvI2L src) mask));
+
+  format %{ "zext.w    $dst, $src\t# ui2l, #@convUI2L_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ zext_w(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg_shift);
+%}
+
+// Convert oop into int for vectors alignment masking
+instruct convP2I_rvb(iRegINoSp dst, iRegP src) %{
+  predicate(UseRVB);
+  match(Set dst (ConvL2I (CastP2X src)));
+
+  format %{ "zext.w    $dst, $src\t# ptr -> int @convP2I_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ zext_w(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// sign extend byte, used by type conversion between byte and short/int
+instruct sextByte_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_24 lshift, immI_24 rshift) %{
+  predicate(UseRVB);
+  match(Set dst (RShiftI (LShiftI src lshift) rshift));
+
+  format %{ "sext.b    $dst, $src\t# sextByte, #@sextByte_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ sext_b(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// long to byte
+instruct convL2Byte_reg_reg_rvb(iRegINoSp dst, iRegILNPNoSp src, immI_56 lshift, immI_56 rshift) %{
+  predicate(UseRVB);
+  match(Set dst (RShiftL (LShiftL src lshift) rshift));
+
+  format %{ "sext.b    $dst, $src\t# l2byte, #@convL2Byte_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ sext_b(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// int to short
+instruct convI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16 lshift, immI_16 rshift) %{
+  predicate(UseRVB);
+  match(Set dst (RShiftI (LShiftI src lshift) rshift));
+
+  format %{ "sext.h    $dst, $src\t# i2s, #@convI2S_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ sext_h(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// long to short
+instruct convL2S_reg_reg_rvb(iRegINoSp dst, iRegILNPNoSp src, immI_48 lshift, immI_48 rshift) %{
+  predicate(UseRVB);
+  match(Set dst (RShiftL (LShiftL src lshift) rshift));
+
+  format %{ "sext.h    $dst, $src\t# l2s, #@convL2S_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ sext_h(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// unsigned int to short
+instruct convUI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %{
+  predicate(UseRVB);
+  match(Set dst (AndI src mask));
+
+  format %{ "zext.h    $dst, $src\t# ui2s, #@convUI2S_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ zext_h(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// unsigned long to short
+instruct convUL2S_reg_reg_rvb(iRegINoSp dst, iRegLNoSp src, immL_16bits mask) %{
+  predicate(UseRVB);
+  match(Set dst (AndL (ConvI2L src) mask));
+
+  format %{ "zext.h    $dst, $src\t# ul2s, #@convUL2S_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ zext_h(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// byte to long
+instruct convByte2L_reg_reg_rvb(iRegLNoSp dst, iRegILNPNoSp src, immI_56 lshift, immI_56 rshift) %{
+  predicate(UseRVB);
+  match(Set dst (RShiftL (LShiftL src lshift) rshift));
+
+  format %{ "sext.b    $dst, $src\t# byte2l, #@convByte2L_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ sext_b(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// short to int
+instruct convS2I_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16 lshift, immI_16 rshift) %{
+  predicate(UseRVB);
+  match(Set dst (RShiftI (LShiftI src lshift) rshift));
+
+  format %{ "sext.h    $dst, $src\t# s2i, #@convS2I_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ sext_h(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// short to long
+instruct convS2L_reg_reg_rvb(iRegLNoSp dst, iRegIorL2I src, immI_48 lshift, immI_48 rshift) %{
+  predicate(UseRVB);
+  match(Set dst (RShiftL (LShiftL src lshift) rshift));
+
+  format %{ "sext.h    $dst, $src\t# s2l, #@convS2L_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ sext_h(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// unsigned short to int
+instruct convUS2I_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %{
+  predicate(UseRVB);
+  match(Set dst (AndI src mask));
+
+  format %{ "zext.h    $dst, $src\t# us2i, #@convUS2I_reg_reg_rvb" %}
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ zext_h(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}
+
+// unsigned short to long
+instruct convUS2L_reg_reg_rvb(iRegLNoSp dst, iRegILNPNoSp src, immL_16bits mask) %{
+  predicate(UseRVB);
+  match(Set dst (AndL (ConvI2L src) mask));
+
+  format %{ "zext.h    $dst, $src\t# us2l, #@convUS2L_reg_reg_rvb" %}
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ zext_h(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg);
+%}

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -101,22 +101,6 @@ instruct rolL_reg_rvb(iRegLNoSp dst, iRegL src, iRegI shift) %{
   ins_pipe(ialu_reg_reg);
 %}
 
-// unsigned int to long (zero extend)
-// this pattern occurs in bigmath arithmetic
-instruct convUI2L_reg_reg_rvb(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %{
-  predicate(UseRVB);
-  match(Set dst (AndL (ConvI2L src) mask));
-
-  format %{ "zext.w    $dst, $src\t# ui2l, #@convUI2L_reg_reg_rvb" %}
-
-  ins_cost(ALU_COST);
-  ins_encode %{
-    __ zext_w(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(ialu_reg_shift);
-%}
-
 // Convert oop into int for vectors alignment masking
 instruct convP2I_rvb(iRegINoSp dst, iRegP src) %{
   predicate(UseRVB);
@@ -132,12 +116,12 @@ instruct convP2I_rvb(iRegINoSp dst, iRegP src) %{
   ins_pipe(ialu_reg);
 %}
 
-// sign extend byte, used by type conversion between byte and short/int
-instruct sextByte_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_24 lshift, immI_24 rshift) %{
+// byte to int
+instruct convB2I_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_24 lshift, immI_24 rshift) %{
   predicate(UseRVB);
   match(Set dst (RShiftI (LShiftI src lshift) rshift));
 
-  format %{ "sext.b    $dst, $src\t# sextByte, #@sextByte_reg_reg_rvb" %}
+  format %{ "sext.b    $dst, $src\t# b2i, #@convB2I_reg_reg_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -162,12 +146,12 @@ instruct convI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16 lshift, immI
   ins_pipe(ialu_reg);
 %}
 
-// unsigned int to short
-instruct convUI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %{
+// short to unsigned int
+instruct convS2UI_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %{
   predicate(UseRVB);
   match(Set dst (AndI src mask));
 
-  format %{ "zext.h    $dst, $src\t# ui2s, #@convUI2S_reg_reg_rvb" %}
+  format %{ "zext.h    $dst, $src\t# s2ui, #@convS2UI_reg_reg_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -175,4 +159,19 @@ instruct convUI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %
   %}
 
   ins_pipe(ialu_reg);
+%}
+
+// int to unsigned long (zero extend)
+instruct convI2UL_reg_reg_rvb(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %{
+  predicate(UseRVB);
+  match(Set dst (AndL (ConvI2L src) mask));
+
+  format %{ "zext.w    $dst, $src\t# i2ul, #@convI2UL_reg_reg_rvb" %}
+
+  ins_cost(ALU_COST);
+  ins_encode %{
+    __ zext_w(as_Register($dst$$reg), as_Register($src$$reg));
+  %}
+
+  ins_pipe(ialu_reg_shift);
 %}

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -147,42 +147,12 @@ instruct sextByte_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_24 lshift, imm
   ins_pipe(ialu_reg);
 %}
 
-// long to byte
-instruct convL2Byte_reg_reg_rvb(iRegINoSp dst, iRegILNPNoSp src, immI_56 lshift, immI_56 rshift) %{
-  predicate(UseRVB);
-  match(Set dst (RShiftL (LShiftL src lshift) rshift));
-
-  format %{ "sext.b    $dst, $src\t# l2byte, #@convL2Byte_reg_reg_rvb" %}
-
-  ins_cost(ALU_COST);
-  ins_encode %{
-    __ sext_b(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(ialu_reg);
-%}
-
 // int to short
 instruct convI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16 lshift, immI_16 rshift) %{
   predicate(UseRVB);
   match(Set dst (RShiftI (LShiftI src lshift) rshift));
 
   format %{ "sext.h    $dst, $src\t# i2s, #@convI2S_reg_reg_rvb" %}
-
-  ins_cost(ALU_COST);
-  ins_encode %{
-    __ sext_h(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(ialu_reg);
-%}
-
-// long to short
-instruct convL2S_reg_reg_rvb(iRegINoSp dst, iRegILNPNoSp src, immI_48 lshift, immI_48 rshift) %{
-  predicate(UseRVB);
-  match(Set dst (RShiftL (LShiftL src lshift) rshift));
-
-  format %{ "sext.h    $dst, $src\t# l2s, #@convL2S_reg_reg_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -199,94 +169,6 @@ instruct convUI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %
 
   format %{ "zext.h    $dst, $src\t# ui2s, #@convUI2S_reg_reg_rvb" %}
 
-  ins_cost(ALU_COST);
-  ins_encode %{
-    __ zext_h(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(ialu_reg);
-%}
-
-// unsigned long to short
-instruct convUL2S_reg_reg_rvb(iRegINoSp dst, iRegLNoSp src, immL_16bits mask) %{
-  predicate(UseRVB);
-  match(Set dst (AndL (ConvI2L src) mask));
-
-  format %{ "zext.h    $dst, $src\t# ul2s, #@convUL2S_reg_reg_rvb" %}
-
-  ins_cost(ALU_COST);
-  ins_encode %{
-    __ zext_h(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(ialu_reg);
-%}
-
-// byte to long
-instruct convByte2L_reg_reg_rvb(iRegLNoSp dst, iRegILNPNoSp src, immI_56 lshift, immI_56 rshift) %{
-  predicate(UseRVB);
-  match(Set dst (RShiftL (LShiftL src lshift) rshift));
-
-  format %{ "sext.b    $dst, $src\t# byte2l, #@convByte2L_reg_reg_rvb" %}
-
-  ins_cost(ALU_COST);
-  ins_encode %{
-    __ sext_b(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(ialu_reg);
-%}
-
-// short to int
-instruct convS2I_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16 lshift, immI_16 rshift) %{
-  predicate(UseRVB);
-  match(Set dst (RShiftI (LShiftI src lshift) rshift));
-
-  format %{ "sext.h    $dst, $src\t# s2i, #@convS2I_reg_reg_rvb" %}
-
-  ins_cost(ALU_COST);
-  ins_encode %{
-    __ sext_h(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(ialu_reg);
-%}
-
-// short to long
-instruct convS2L_reg_reg_rvb(iRegLNoSp dst, iRegIorL2I src, immI_48 lshift, immI_48 rshift) %{
-  predicate(UseRVB);
-  match(Set dst (RShiftL (LShiftL src lshift) rshift));
-
-  format %{ "sext.h    $dst, $src\t# s2l, #@convS2L_reg_reg_rvb" %}
-
-  ins_cost(ALU_COST);
-  ins_encode %{
-    __ sext_h(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(ialu_reg);
-%}
-
-// unsigned short to int
-instruct convUS2I_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %{
-  predicate(UseRVB);
-  match(Set dst (AndI src mask));
-
-  format %{ "zext.h    $dst, $src\t# us2i, #@convUS2I_reg_reg_rvb" %}
-  ins_cost(ALU_COST);
-  ins_encode %{
-    __ zext_h(as_Register($dst$$reg), as_Register($src$$reg));
-  %}
-
-  ins_pipe(ialu_reg);
-%}
-
-// unsigned short to long
-instruct convUS2L_reg_reg_rvb(iRegLNoSp dst, iRegILNPNoSp src, immL_16bits mask) %{
-  predicate(UseRVB);
-  match(Set dst (AndL (ConvI2L src) mask));
-
-  format %{ "zext.h    $dst, $src\t# us2l, #@convUS2L_reg_reg_rvb" %}
   ins_cost(ALU_COST);
   ins_encode %{
     __ zext_h(as_Register($dst$$reg), as_Register($src$$reg));


### PR DESCRIPTION
This PR implements bitwise instructions of RISC-V BitManipulation Extension, including ror/rolw/ror/rori/roriw/rorw. New C2 instructions are covered by following JTREG tests:
- test/hotspot/jtreg/compiler/intrinsics/TestRotate.java
- test/jdk/java/lang 

This PR also add zext/sext C2 instructions that were missed in JDK-8279213

Hotspot and jdk tier1 test on QEMU (enable RVB) are passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279344](https://bugs.openjdk.java.net/browse/JDK-8279344): riscv: RVB: Add bitwise rotation instructions


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/39/head:pull/39` \
`$ git checkout pull/39`

Update a local copy of the PR: \
`$ git checkout pull/39` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/39/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 39`

View PR using the GUI difftool: \
`$ git pr show -t 39`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/39.diff">https://git.openjdk.java.net/riscv-port/pull/39.diff</a>

</details>
