### PR TITLE
8279346: riscv: Unnecessary sign extension in BigInteger intrinsics

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv_v.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv_v.hpp
@@ -27,14 +27,11 @@
 #define CPU_RISCV_ASSEMBLER_RISCV_V_HPP
 
 enum SEW {
-  e8    = 0b000,
-  e16   = 0b001,
-  e32   = 0b010,
-  e64   = 0b011,
-  e128  = 0b100,
-  e256  = 0b101,
-  e512  = 0b110,
-  e1024 = 0b111,
+  e8,
+  e16,
+  e32,
+  e64,
+  RESERVED,
 };
 
 enum LMUL {
@@ -57,14 +54,18 @@ enum VTA {
   ta, // agnostic
 };
 
-static Assembler::SEW elemBytes_to_sew(int esize) {
-  assert(esize > 0 && esize <= 64 && is_power_of_2(esize), "unsupported element size");
-  return (Assembler::SEW) log2i_exact(esize);
+static Assembler::SEW elembytes_to_sew(int ebytes) {
+  assert(ebytes > 0 && ebytes <= 8, "unsupported element size");
+  return (Assembler::SEW) exact_log2(ebytes);
+}
+
+static Assembler::SEW elemtype_to_sew(BasicType etype) {
+  return Assembler::elembytes_to_sew(type2aelembytes(etype));
 }
 
 #define patch_vtype(hsb, lsb, vlmul, vsew, vta, vma, vill)   \
     if (vill == 1) {                                         \
-      guarantee((vlmul | vsew | vsew | vta | vma == 0),      \
+      guarantee((vlmul | vsew | vta | vma == 0),             \
                 "the other bits in vtype shall be zero");    \
     }                                                        \
     patch((address)&insn, lsb + 2, lsb, vlmul);              \

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3053,7 +3053,6 @@ void MacroAssembler::mul_add(Register out, Register in, Register offset,
   Label L_tail_loop, L_unroll, L_end;
   mv(tmp, out);
   mv(out, zr);
-  sign_extend(len, len, 32);
   blez(len, L_end);
   zero_extend(k, k, 32);
   slliw(t0, offset, LogBytesPerInt);
@@ -3411,8 +3410,8 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen, Register y, Regi
   const Register product = xlen;
   const Register x_xstart = zlen; // reuse register
 
-  sign_extend(idx, ylen, 32); // idx = ylen;
-  sign_extend(kdx, zlen, 32); // kdx = xlen+ylen;
+  mv(idx, ylen); // idx = ylen;
+  mv(kdx, zlen); // kdx = xlen+ylen;
   mv(carry, zr); // carry = 0;
 
   Label L_multiply_64_x_64_loop, L_done;
@@ -3436,7 +3435,7 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen, Register y, Regi
     Label L_second_loop_unaligned;
     bind(L_second_loop_unaligned);
     mv(carry, zr);
-    sign_extend(jdx, ylen, 32);
+    mv(jdx, ylen);
     subw(xstart, xstart, 1);
     bltz(xstart, L_done);
     sub(sp, sp, 2 * wordSize);
@@ -3515,7 +3514,7 @@ void MacroAssembler::multiply_to_len(Register x, Register xlen, Register y, Regi
 
   bind(L_second_loop_aligned);
   mv(carry, zr); // carry = 0;
-  sign_extend(jdx, ylen, 32); // j = ystart+1
+  mv(jdx, ylen); // j = ystart+1
 
   subw(xstart, xstart, 1); // i = xstart-1;
   bltz(xstart, L_done);

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -33,13 +33,10 @@ source_hpp %{
 %}
 
 source %{
-  static Assembler::SEW elemType_to_sew(BasicType bt) {
-    return Assembler::elemBytes_to_sew(type2aelembytes(bt));
-  }
 
   static void loadStore(C2_MacroAssembler masm, bool is_store,
                         VectorRegister reg, BasicType bt, Register base) {
-    Assembler::SEW sew = elemType_to_sew(bt);
+    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     masm.vsetvli(t0, x0, sew);
     if (is_store) {
       masm.vsex_v(reg, base, sew);
@@ -51,19 +48,19 @@ source %{
   bool op_vec_supported(int opcode) {
     switch (opcode) {
       // No multiply reduction instructions
-      case Op_MulReductionVD: // fall through
-      case Op_MulReductionVF: // fall through
-      case Op_MulReductionVI: // fall through
-      case Op_MulReductionVL: // fall through
+      case Op_MulReductionVD:
+      case Op_MulReductionVF:
+      case Op_MulReductionVI:
+      case Op_MulReductionVL:
       // Others
-      case Op_Extract:        // fall through
-      case Op_ExtractB:       // fall through
-      case Op_ExtractC:       // fall through
-      case Op_ExtractD:       // fall through
-      case Op_ExtractF:       // fall through
-      case Op_ExtractI:       // fall through
-      case Op_ExtractL:       // fall through
-      case Op_ExtractS:       // fall through
+      case Op_Extract:
+      case Op_ExtractB:
+      case Op_ExtractC:
+      case Op_ExtractD:
+      case Op_ExtractF:
+      case Op_ExtractI:
+      case Op_ExtractL:
+      case Op_ExtractS:
       case Op_ExtractUB:
       // Vector API specific
       case Op_AndReductionV:
@@ -370,7 +367,7 @@ instruct vmax(vReg dst, vReg src1, vReg src2) %{
   format %{ "vmax.vv $dst, $src1, $src2\t#@vmax" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SEW sew = elemType_to_sew(bt);
+    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     __ vsetvli(t0, x0, sew);
     __ vmax_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));
@@ -386,7 +383,7 @@ instruct vmin(vReg dst, vReg src1, vReg src2) %{
   format %{ "vmin.vv $dst, $src1, $src2\t#@vmin" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    Assembler::SEW sew = elemType_to_sew(bt);
+    Assembler::SEW sew = Assembler::elemtype_to_sew(bt);
     __ vsetvli(t0, x0, sew);
     __ vmin_vv(as_VectorRegister($dst$$reg),
                as_VectorRegister($src1$$reg), as_VectorRegister($src2$$reg));

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -839,8 +839,7 @@ class StubGenerator: public StubCodeGenerator {
 
     const Register src = x30, dst = x31, vl = x14, cnt = x15, tmp1 = x16, tmp2 = x17;
     assert_different_registers(s, d, cnt, vl, tmp, tmp1, tmp2);
-    Assembler::SEW sew = Assembler::elemBytes_to_sew(granularity);
-    assert(sew >= Assembler::e8 && sew <= Assembler::e64, "illegal SEW");
+    Assembler::SEW sew = Assembler::elembytes_to_sew(granularity);
     Label loop_forward, loop_backward, done;
 
     __ mv(dst, d);


### PR DESCRIPTION
Reference: https://github.com/riscv-non-isa/riscv-elf-psabi-doc

" Scalars that are at most XLEN bits wide are passed in a single argument register, or on the stack by value if none is available.
When passed in registers or on the stack, integer scalars narrower than XLEN bits are widened according to the sign of their type up to 32 bits, then sign-extended to XLEN bits.
When passed in registers or on the stack, floating-point types narrower than XLEN bits are widened to XLEN bits, with the upper bits undefined."

So there is no need to do sign extension for signed integer input parameters.

Performed full jtreg tests with qemu without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279346](https://bugs.openjdk.java.net/browse/JDK-8279346): riscv: Unnecessary sign extension in BigInteger intrinsics


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/40.diff">https://git.openjdk.java.net/riscv-port/pull/40.diff</a>

</details>
