### PR TITLE
8279487: riscv: Fix bad AD file when UseRVB is disabled

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -1772,6 +1772,9 @@ const bool Matcher::match_rule_supported(int opcode) {
       return UseRVV;
     case Op_EncodeISOArray:
       return UseRVV && SpecialEncodeISOArray;
+    case Op_RotateRight:
+    case Op_RotateLeft:
+      return UseRVB;
   }
 
   return true; // Per default match rules are supported.


### PR DESCRIPTION
After JDK-8279344, test/hotspot/jtreg/compiler/intrinsics/TestRotate.java will report bad AD file error in fastdebug when UseRVB is disabled.
Some match rules for `RotateRight` and `RotateLeft` are added by  [JDK-8279344](https://bugs.openjdk.java.net/browse/JDK-8279344) , which is under predicate of UseRVB. But `match_rule_supported(Op_RotateRight/Op_RotateLeft)` still returns true even when UseRVB is disabled. This will cause the bad AD file error on fastdebug JDK. 
This PR fixes this issue by setting `match_rule_supported(Op_RotateRight)` and `match_rule_supported(Op_RotateLeft)` to false when UseRVB is disabled.

test/hotspot/jtreg/compiler/intrinsics/TestRotate.java passed with/without UseRVB on fastdebug JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279487](https://bugs.openjdk.java.net/browse/JDK-8279487): riscv: Fix bad AD file when UseRVB is disabled


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/41.diff">https://git.openjdk.java.net/riscv-port/pull/41.diff</a>

</details>
