### PR TITLE
8279827: riscv: RVB: Add shift and add instructions

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -1899,11 +1899,17 @@ enum Nf {
     emit(insn);                                         \
   }
 
-  INSN(add_uw, 0b0111011, 0b000, 0b0000100);
-  INSN(rol,    0b0110011, 0b001, 0b0110000);
-  INSN(rolw,   0b0111011, 0b001, 0b0110000);
-  INSN(ror,    0b0110011, 0b101, 0b0110000);
-  INSN(rorw,   0b0111011, 0b101, 0b0110000);
+  INSN(add_uw,    0b0111011, 0b000, 0b0000100);
+  INSN(rol,       0b0110011, 0b001, 0b0110000);
+  INSN(rolw,      0b0111011, 0b001, 0b0110000);
+  INSN(ror,       0b0110011, 0b101, 0b0110000);
+  INSN(rorw,      0b0111011, 0b101, 0b0110000);
+  INSN(sh1add,    0b0110011, 0b010, 0b0010000);
+  INSN(sh2add,    0b0110011, 0b100, 0b0010000);
+  INSN(sh3add,    0b0110011, 0b110, 0b0010000);
+  INSN(sh1add_uw, 0b0111011, 0b010, 0b0010000);
+  INSN(sh2add_uw, 0b0111011, 0b100, 0b0010000);
+  INSN(sh3add_uw, 0b0111011, 0b110, 0b0010000);
 
 #undef INSN
 

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_arraycopy_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_arraycopy_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -349,12 +349,10 @@ void LIR_Assembler::emit_arraycopy(LIR_OpArrayCopy* op) {
 void LIR_Assembler::arraycopy_prepare_params(Register src, Register src_pos, Register length,
                                              Register dst, Register dst_pos, BasicType basic_type) {
   int scale = array_element_size(basic_type);
-  __ slli(t0, src_pos, scale);
-  __ add(c_rarg0, src, t0);
+  __ shadd(c_rarg0, src_pos, src, t0, scale);
   __ add(c_rarg0, c_rarg0, arrayOopDesc::base_offset_in_bytes(basic_type));
   assert_different_registers(c_rarg0, dst, dst_pos, length);
-  __ slli(t0, dst_pos, scale);
-  __ add(c_rarg1, dst, t0);
+  __ shadd(c_rarg1, dst_pos, dst, t0, scale);
   __ add(c_rarg1, c_rarg1, arrayOopDesc::base_offset_in_bytes(basic_type));
   assert_different_registers(c_rarg1, dst, length);
   __ mv(c_rarg2, length);

--- a/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_LIRAssembler_riscv.cpp
@@ -1965,8 +1965,7 @@ Address LIR_Assembler::as_Address(LIR_Address* addr, Register tmp) {
       index = index_op->as_register_lo();
     }
     if (scale != 0) {
-      __ slli(tmp, index, scale);
-      __ add(tmp, base, tmp);
+      __ shadd(tmp, index, base, tmp, scale);
     } else {
       __ add(tmp, base, index);
     }

--- a/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_MacroAssembler_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -272,8 +272,7 @@ void C1_MacroAssembler::allocate_array(Register obj, Register len, Register tmp1
   const Register arr_size = tmp2; // okay to be the same
   // align object end
   mv(arr_size, (int32_t)header_size * BytesPerWord + MinObjAlignmentInBytesMask);
-  slli(t0, len, f);
-  add(arr_size, arr_size, t0);
+  shadd(arr_size, len, arr_size, t0, f);
   andi(arr_size, arr_size, ~(uint)MinObjAlignmentInBytesMask);
 
   try_allocate(obj, arr_size, 0, tmp1, tmp2, slow_case);

--- a/src/hotspot/cpu/riscv/gc/shared/cardTableBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/shared/cardTableBarrierSetAssembler_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -70,8 +70,8 @@ void CardTableBarrierSetAssembler::gen_write_ref_array_post_barrier(MacroAssembl
   const Register end = count;
 
   __ beqz(count, L_done); // zero count - nothing to do
-  __ slli(count, count, LogBytesPerHeapOop);
-  __ add(end, start, count); // end = start + count << LogBytesPerHeapOop
+  // end = start + count << LogBytesPerHeapOop
+  __ shadd(end, count, start, count, LogBytesPerHeapOop);
   __ sub(end, end, BytesPerHeapOop); // last element address to make inclusive
 
   __ srli(start, start, CardTable::card_shift());

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -3897,11 +3897,11 @@ void MacroAssembler::shadd(Register Rd, Register Rs1, Register Rs2, Register tmp
     }
   }
 
-  if (shamt == 0) {
-    add(Rd, Rs1, Rs2);
-  } else {
+  if (shamt != 0) {
     slli(tmp, Rs1, shamt);
     add(Rd, Rs2, tmp);
+  } else {
+    add(Rd, Rs1, Rs2);
   }
 }
 

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -681,6 +681,9 @@ class MacroAssembler: public Assembler {
   void fill_words(Register base, Register cnt, Register value);
   void zero_memory(Register addr, Register len, Register tmp1);
 
+  // shift left by shamt and add
+  void shadd(Register Rd, Register Rs1, Register Rs2, Register tmp, int shamt);
+
   // Here the float instructions with safe deal with some exceptions.
   // e.g. convert from NaN, +Inf, -Inf to int, float, double
   // will trigger exception, we need to deal with these situations

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3029,29 +3029,9 @@ operand immLOffset()
 %}
 
 // Scale values
-operand immIScale1()
+operand immIScale()
 %{
-  predicate(n->get_int() == 1);
-  match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-operand immIScale2()
-%{
-  predicate(n->get_int() == 2);
-  match(ConI);
-
-  op_cost(0);
-  format %{ %}
-  interface(CONST_INTER);
-%}
-
-operand immIScale3()
-%{
-  predicate(n->get_int() == 3);
+  predicate(1 <= n->get_int() && (n->get_int() <= 3));
   match(ConI);
 
   op_cost(0);

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -3028,6 +3028,37 @@ operand immLOffset()
   interface(CONST_INTER);
 %}
 
+// Scale values
+operand immIScale1()
+%{
+  predicate(n->get_int() == 1);
+  match(ConI);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+operand immIScale2()
+%{
+  predicate(n->get_int() == 2);
+  match(ConI);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
+operand immIScale3()
+%{
+  predicate(n->get_int() == 3);
+  match(ConI);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 // Integer 32 bit Register Operands
 operand iRegI()
 %{

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -29,7 +29,7 @@ instruct rorI_imm_rvb(iRegINoSp dst, iRegI src, immI shift) %{
   predicate(UseRVB);
   match(Set dst (RotateRight src shift));
 
-  format %{ "roriw    $dst, $src, ($shift & 0x1f)\t#@rorI_imm_rvb" %}
+  format %{ "roriw  $dst, $src, ($shift & 0x1f)\t#@rorI_imm_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -43,7 +43,7 @@ instruct rorL_imm_rvb(iRegLNoSp dst, iRegL src, immI shift) %{
   predicate(UseRVB);
   match(Set dst (RotateRight src shift));
 
-  format %{ "rori    $dst, $src, ($shift & 0x3f)\t#@rorL_imm_rvb" %}
+  format %{ "rori  $dst, $src, ($shift & 0x3f)\t#@rorL_imm_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -57,7 +57,7 @@ instruct rorI_reg_rvb(iRegINoSp dst, iRegI src, iRegI shift) %{
   predicate(UseRVB);
   match(Set dst (RotateRight src shift));
 
-  format %{ "rorw    $dst, $src, $shift\t#@rorI_reg_rvb" %}
+  format %{ "rorw  $dst, $src, $shift\t#@rorI_reg_rvb" %}
   ins_cost(ALU_COST);
   ins_encode %{
     __ rorw(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
@@ -69,7 +69,7 @@ instruct rorL_reg_rvb(iRegLNoSp dst, iRegL src, iRegI shift) %{
   predicate(UseRVB);
   match(Set dst (RotateRight src shift));
 
-  format %{ "ror    $dst, $src, $shift\t#@rorL_reg_rvb" %}
+  format %{ "ror  $dst, $src, $shift\t#@rorL_reg_rvb" %}
   ins_cost(ALU_COST);
   ins_encode %{
     __ ror(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
@@ -81,7 +81,7 @@ instruct rolI_reg_rvb(iRegINoSp dst, iRegI src, iRegI shift) %{
   predicate(UseRVB);
   match(Set dst (RotateLeft src shift));
 
-  format %{ "rolw    $dst, $src, $shift\t#@rolI_reg_rvb" %}
+  format %{ "rolw  $dst, $src, $shift\t#@rolI_reg_rvb" %}
   ins_cost(ALU_COST);
   ins_encode %{
     __ rolw(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
@@ -93,7 +93,7 @@ instruct rolL_reg_rvb(iRegLNoSp dst, iRegL src, iRegI shift) %{
   predicate(UseRVB);
   match(Set dst (RotateLeft src shift));
 
-  format %{ "rol    $dst, $src, $shift\t#@rolL_reg_rvb" %}
+  format %{ "rol  $dst, $src, $shift\t#@rolL_reg_rvb" %}
   ins_cost(ALU_COST);
   ins_encode %{
     __ rol(as_Register($dst$$reg), as_Register($src$$reg), as_Register($shift$$reg));
@@ -106,7 +106,7 @@ instruct convP2I_rvb(iRegINoSp dst, iRegP src) %{
   predicate(UseRVB);
   match(Set dst (ConvL2I (CastP2X src)));
 
-  format %{ "zext.w    $dst, $src\t# ptr -> int @convP2I_rvb" %}
+  format %{ "zext.w  $dst, $src\t# ptr -> int @convP2I_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -121,7 +121,7 @@ instruct convB2I_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_24 lshift, immI
   predicate(UseRVB);
   match(Set dst (RShiftI (LShiftI src lshift) rshift));
 
-  format %{ "sext.b    $dst, $src\t# b2i, #@convB2I_reg_reg_rvb" %}
+  format %{ "sext.b  $dst, $src\t# b2i, #@convB2I_reg_reg_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -136,7 +136,7 @@ instruct convI2S_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16 lshift, immI
   predicate(UseRVB);
   match(Set dst (RShiftI (LShiftI src lshift) rshift));
 
-  format %{ "sext.h    $dst, $src\t# i2s, #@convI2S_reg_reg_rvb" %}
+  format %{ "sext.h  $dst, $src\t# i2s, #@convI2S_reg_reg_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -151,7 +151,7 @@ instruct convS2UI_reg_reg_rvb(iRegINoSp dst, iRegIorL2I src, immI_16bits mask) %
   predicate(UseRVB);
   match(Set dst (AndI src mask));
 
-  format %{ "zext.h    $dst, $src\t# s2ui, #@convS2UI_reg_reg_rvb" %}
+  format %{ "zext.h  $dst, $src\t# s2ui, #@convS2UI_reg_reg_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -166,7 +166,7 @@ instruct convI2UL_reg_reg_rvb(iRegLNoSp dst, iRegIorL2I src, immL_32bits mask) %
   predicate(UseRVB);
   match(Set dst (AndL (ConvI2L src) mask));
 
-  format %{ "zext.w    $dst, $src\t# i2ul, #@convI2UL_reg_reg_rvb" %}
+  format %{ "zext.w  $dst, $src\t# i2ul, #@convI2UL_reg_reg_rvb" %}
 
   ins_cost(ALU_COST);
   ins_encode %{
@@ -231,4 +231,198 @@ instruct bytes_reverse_short_rvb(iRegINoSp dst, iRegIorL2I src) %{
   %}
 
   ins_pipe(ialu_reg);
+%}
+
+// Shift Add Pointer
+instruct sh1addP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale1 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddP src1 (LShiftL src2 imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh1add  $dst, $src2, src1\t# ptr, #@sh1addP_reg_reg_rvb" %}
+
+  ins_encode %{
+    __ sh1add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh2addP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale2 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddP src1 (LShiftL src2 imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh2add  $dst, $src2, src1\t# ptr, #@sh2addP_reg_reg_rvb" %}
+
+  ins_encode %{
+    __ sh2add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh3addP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale3 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddP src1 (LShiftL src2 imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh3add  $dst, $src2, $src1\t# ptr, #@sh3addP_reg_reg_rvb" %}
+
+  ins_encode %{
+    __ sh3add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh1addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, immIScale1 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh1add  $dst, $src2, src1\t# ptr, #@sh1addP_reg_reg_ext_rvb" %}
+
+  ins_encode %{
+    __ sh1add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh2addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, immIScale2 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh2add  $dst, $src2, src1\t# ptr, #@sh2addP_reg_reg_ext_rvb" %}
+
+  ins_encode %{
+    __ sh2add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh3addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, immIScale3 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh3add  $dst, $src2, src1\t# ptr, #@sh3addP_reg_reg_ext_rvb" %}
+
+  ins_encode %{
+    __ sh3add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+// Shift Add Long
+instruct sh1addL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale1 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddL src1 (LShiftL src2 imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh1add  $dst, $src2, $src1\t#@sh1addL_reg_reg_rvb" %}
+
+  ins_encode %{
+    __ sh1add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh2addL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale2 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddL src1 (LShiftL src2 imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh2add  $dst, $src2, $src1\t#@sh2addL_reg_reg_rvb" %}
+
+  ins_encode %{
+    __ sh2add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh3addL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale3 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddL src1 (LShiftL src2 imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh3add  $dst, $src2, $src1\t#@sh3addL_reg_reg_rvb" %}
+
+  ins_encode %{
+    __ sh3add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh1addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIScale1 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh1add  $dst, $src2, $src1\t#@sh1addL_reg_reg_ext_rvb" %}
+
+  ins_encode %{
+    __ sh1add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh2addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIScale2 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh2add  $dst, $src2, $src1\t#@sh2addL_reg_reg_ext_rvb" %}
+
+  ins_encode %{
+    __ sh2add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
+%}
+
+instruct sh3addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIScale3 imm) %{
+  predicate(UseRVB);
+  match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
+
+  ins_cost(ALU_COST);
+  format %{ "sh3add  $dst, $src2, $src1\t#@sh3addL_reg_reg_ext_rvb" %}
+
+  ins_encode %{
+    __ sh3add(as_Register($dst$$reg),
+              as_Register($src2$$reg),
+              as_Register($src1$$reg));
+  %}
+
+  ins_pipe(ialu_reg_reg);
 %}

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -282,7 +282,7 @@ instruct sh3addP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale3 i
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct sh1addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, immIScale1 imm) %{
+instruct sh1addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale1 imm) %{
   predicate(UseRVB);
   match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
 
@@ -298,7 +298,7 @@ instruct sh1addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, imm
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct sh2addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, immIScale2 imm) %{
+instruct sh2addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale2 imm) %{
   predicate(UseRVB);
   match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
 
@@ -314,7 +314,7 @@ instruct sh2addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, imm
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct sh3addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegIorL2I src2, immIScale3 imm) %{
+instruct sh3addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale3 imm) %{
   predicate(UseRVB);
   match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
 
@@ -379,7 +379,7 @@ instruct sh3addL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale3 i
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct sh1addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIScale1 imm) %{
+instruct sh1addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale1 imm) %{
   predicate(UseRVB);
   match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
 
@@ -395,7 +395,7 @@ instruct sh1addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, imm
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct sh2addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIScale2 imm) %{
+instruct sh2addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale2 imm) %{
   predicate(UseRVB);
   match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
 
@@ -411,7 +411,7 @@ instruct sh2addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, imm
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct sh3addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegIorL2I src2, immIScale3 imm) %{
+instruct sh3addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale3 imm) %{
   predicate(UseRVB);
   match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
 

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -234,194 +234,74 @@ instruct bytes_reverse_short_rvb(iRegINoSp dst, iRegIorL2I src) %{
 %}
 
 // Shift Add Pointer
-instruct sh1addP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale1 imm) %{
+instruct shaddP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale imm) %{
   predicate(UseRVB);
   match(Set dst (AddP src1 (LShiftL src2 imm)));
 
   ins_cost(ALU_COST);
-  format %{ "sh1add  $dst, $src2, src1\t# ptr, #@sh1addP_reg_reg_rvb" %}
+  format %{ "shadd  $dst, $src2, $src1, $imm\t# ptr, #@shaddP_reg_reg_rvb" %}
 
   ins_encode %{
-    __ sh1add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
+    __ shadd(as_Register($dst$$reg),
+             as_Register($src2$$reg),
+             as_Register($src1$$reg),
+             t0,
+             $imm$$constant);
   %}
 
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct sh2addP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale2 imm) %{
-  predicate(UseRVB);
-  match(Set dst (AddP src1 (LShiftL src2 imm)));
-
-  ins_cost(ALU_COST);
-  format %{ "sh2add  $dst, $src2, src1\t# ptr, #@sh2addP_reg_reg_rvb" %}
-
-  ins_encode %{
-    __ sh2add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
-  %}
-
-  ins_pipe(ialu_reg_reg);
-%}
-
-instruct sh3addP_reg_reg_rvb(iRegPNoSp dst, iRegP src1, iRegL src2, immIScale3 imm) %{
-  predicate(UseRVB);
-  match(Set dst (AddP src1 (LShiftL src2 imm)));
-
-  ins_cost(ALU_COST);
-  format %{ "sh3add  $dst, $src2, $src1\t# ptr, #@sh3addP_reg_reg_rvb" %}
-
-  ins_encode %{
-    __ sh3add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
-  %}
-
-  ins_pipe(ialu_reg_reg);
-%}
-
-instruct sh1addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale1 imm) %{
+instruct shaddP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale imm) %{
   predicate(UseRVB);
   match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
 
   ins_cost(ALU_COST);
-  format %{ "sh1add  $dst, $src2, src1\t# ptr, #@sh1addP_reg_reg_ext_rvb" %}
+  format %{ "shadd  $dst, $src2, $src1, $imm\t# ptr, #@shaddP_reg_reg_ext_rvb" %}
 
   ins_encode %{
-    __ sh1add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
-  %}
-
-  ins_pipe(ialu_reg_reg);
-%}
-
-instruct sh2addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale2 imm) %{
-  predicate(UseRVB);
-  match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
-
-  ins_cost(ALU_COST);
-  format %{ "sh2add  $dst, $src2, src1\t# ptr, #@sh2addP_reg_reg_ext_rvb" %}
-
-  ins_encode %{
-    __ sh2add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
-  %}
-
-  ins_pipe(ialu_reg_reg);
-%}
-
-instruct sh3addP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale3 imm) %{
-  predicate(UseRVB);
-  match(Set dst (AddP src1 (LShiftL (ConvI2L src2) imm)));
-
-  ins_cost(ALU_COST);
-  format %{ "sh3add  $dst, $src2, src1\t# ptr, #@sh3addP_reg_reg_ext_rvb" %}
-
-  ins_encode %{
-    __ sh3add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
+    __ shadd(as_Register($dst$$reg),
+             as_Register($src2$$reg),
+             as_Register($src1$$reg)
+             t0,
+             $imm$$constant);
   %}
 
   ins_pipe(ialu_reg_reg);
 %}
 
 // Shift Add Long
-instruct sh1addL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale1 imm) %{
+instruct shaddL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale imm) %{
   predicate(UseRVB);
   match(Set dst (AddL src1 (LShiftL src2 imm)));
 
   ins_cost(ALU_COST);
-  format %{ "sh1add  $dst, $src2, $src1\t#@sh1addL_reg_reg_rvb" %}
+  format %{ "shadd  $dst, $src2, $src1, $imm\t#@shaddL_reg_reg_rvb" %}
 
   ins_encode %{
-    __ sh1add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
+    __ shadd(as_Register($dst$$reg),
+             as_Register($src2$$reg),
+             as_Register($src1$$reg),
+             t0,
+             $imm$$constant);
   %}
 
   ins_pipe(ialu_reg_reg);
 %}
 
-instruct sh2addL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale2 imm) %{
-  predicate(UseRVB);
-  match(Set dst (AddL src1 (LShiftL src2 imm)));
-
-  ins_cost(ALU_COST);
-  format %{ "sh2add  $dst, $src2, $src1\t#@sh2addL_reg_reg_rvb" %}
-
-  ins_encode %{
-    __ sh2add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
-  %}
-
-  ins_pipe(ialu_reg_reg);
-%}
-
-instruct sh3addL_reg_reg_rvb(iRegLNoSp dst, iRegL src1, iRegL src2, immIScale3 imm) %{
-  predicate(UseRVB);
-  match(Set dst (AddL src1 (LShiftL src2 imm)));
-
-  ins_cost(ALU_COST);
-  format %{ "sh3add  $dst, $src2, $src1\t#@sh3addL_reg_reg_rvb" %}
-
-  ins_encode %{
-    __ sh3add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
-  %}
-
-  ins_pipe(ialu_reg_reg);
-%}
-
-instruct sh1addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale1 imm) %{
+instruct shaddL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale imm) %{
   predicate(UseRVB);
   match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
 
   ins_cost(ALU_COST);
-  format %{ "sh1add  $dst, $src2, $src1\t#@sh1addL_reg_reg_ext_rvb" %}
+  format %{ "shadd  $dst, $src2, $src1, $imm\t#@shaddL_reg_reg_ext_rvb" %}
 
   ins_encode %{
-    __ sh1add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
-  %}
-
-  ins_pipe(ialu_reg_reg);
-%}
-
-instruct sh2addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale2 imm) %{
-  predicate(UseRVB);
-  match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
-
-  ins_cost(ALU_COST);
-  format %{ "sh2add  $dst, $src2, $src1\t#@sh2addL_reg_reg_ext_rvb" %}
-
-  ins_encode %{
-    __ sh2add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
-  %}
-
-  ins_pipe(ialu_reg_reg);
-%}
-
-instruct sh3addL_reg_reg_ext_rvb(iRegLNoSp dst, iRegL src1, iRegI src2, immIScale3 imm) %{
-  predicate(UseRVB);
-  match(Set dst (AddL src1 (LShiftL (ConvI2L src2) imm)));
-
-  ins_cost(ALU_COST);
-  format %{ "sh3add  $dst, $src2, $src1\t#@sh3addL_reg_reg_ext_rvb" %}
-
-  ins_encode %{
-    __ sh3add(as_Register($dst$$reg),
-              as_Register($src2$$reg),
-              as_Register($src1$$reg));
+    __ shadd(as_Register($dst$$reg),
+             as_Register($src2$$reg),
+             as_Register($src1$$reg),
+             t0,
+             $imm$$constant);
   %}
 
   ins_pipe(ialu_reg_reg);

--- a/src/hotspot/cpu/riscv/riscv_b.ad
+++ b/src/hotspot/cpu/riscv/riscv_b.ad
@@ -262,7 +262,7 @@ instruct shaddP_reg_reg_ext_rvb(iRegPNoSp dst, iRegP src1, iRegI src2, immIScale
   ins_encode %{
     __ shadd(as_Register($dst$$reg),
              as_Register($src2$$reg),
-             as_Register($src1$$reg)
+             as_Register($src1$$reg),
              t0,
              $imm$$constant);
   %}

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2020, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -456,8 +456,7 @@ address TemplateInterpreterGenerator::generate_return_entry_for(TosState state, 
   __ ld(x11, Address(x11, ConstantPoolCache::base_offset() + ConstantPoolCacheEntry::flags_offset()));
   __ andi(x11, x11, ConstantPoolCacheEntry::parameter_size_mask);
 
-  __ slli(t0, x11, 3);
-  __ add(esp, esp, t0);
+  __ shadd(esp, x11, esp, t0, 3);
 
   // Restore machine SP
   __ ld(t0, Address(xmethod, Method::const_offset()));
@@ -637,8 +636,7 @@ void TemplateInterpreterGenerator::generate_stack_overflow_check(void) {
 
   // locals + overhead, in bytes
   __ mv(x10, overhead_size);
-  __ slli(t0, x13, Interpreter::logStackElementSize);
-  __ add(x10, x10, t0);  // 2 slots per parameter.
+  __ shadd(x10, x13, x10, t0, Interpreter::logStackElementSize);  // 2 slots per parameter.
 
   const Address stack_limit(xthread, JavaThread::stack_overflow_limit_offset());
   __ ld(t0, stack_limit);
@@ -941,8 +939,7 @@ address TemplateInterpreterGenerator::generate_native_entry(bool synchronized) {
   // for natives the size of locals is zero
 
   // compute beginning of parameters (xlocals)
-  __ slli(xlocals, x12, 3);
-  __ add(xlocals, esp, xlocals);
+  __ shadd(xlocals, x12, esp, xlocals, 3);
   __ addi(xlocals, xlocals, -wordSize);
 
   // Pull SP back to minimum size: this avoids holes in the stack
@@ -1334,8 +1331,7 @@ address TemplateInterpreterGenerator::generate_normal_entry(bool synchronized) {
   generate_stack_overflow_check();
 
   // compute beginning of parameters (xlocals)
-  __ slli(t1, x12, 3);
-  __ add(xlocals, esp, t1);
+  __ shadd(xlocals, x12, esp, t1, 3);
   __ add(xlocals, xlocals, -wordSize);
 
   // Make room for additional locals

--- a/src/hotspot/cpu/riscv/templateTable_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateTable_riscv.cpp
@@ -72,16 +72,14 @@ static inline Address aaddress(int n) {
 
 static inline Address iaddress(Register r,  Register temp, InterpreterMacroAssembler* _masm) {
   assert_cond(_masm != NULL);
-  _masm->slli(temp, r, 3);
-  _masm->add(temp, xlocals, temp);
+  _masm->shadd(temp, r, xlocals, temp, 3);
   return Address(temp, 0);
 }
 
 static inline Address laddress(Register r, Register temp,
                                InterpreterMacroAssembler* _masm) {
   assert_cond(_masm != NULL);
-  _masm->slli(temp, r, 3);
-  _masm->add(temp, xlocals, temp);
+  _masm->shadd(temp, r, xlocals, temp, 3);
   return Address(temp, Interpreter::local_offset_in_bytes(1));;
 }
 
@@ -348,8 +346,7 @@ void TemplateTable::ldc(bool wide)
   __ bne(x13, t1, notFloat);
 
   // ftos
-  __ slli(x11, x11, 3);
-  __ add(x11, x12, x11);
+  __ shadd(x11, x11, x12, x11, 3);
   __ flw(f10, Address(x11, base_offset));
   __ push_f(f10);
   __ j(Done);
@@ -360,8 +357,7 @@ void TemplateTable::ldc(bool wide)
   __ bne(x13, t1, notInt);
 
   // itos
-  __ slli(x11, x11, 3);
-  __ add(x11, x12, x11);
+  __ shadd(x11, x11, x12, x11, 3);
   __ lw(x10, Address(x11, base_offset));
   __ push_i(x10);
   __ j(Done);
@@ -438,8 +434,7 @@ void TemplateTable::ldc2_w()
     __ bne(x12, t1, notDouble);
 
     // dtos
-    __ slli(x12, x10, 3);
-    __ add(x12, x11, x12);
+    __ shadd(x12, x10, x11, x12, 3);
     __ fld(f10, Address(x12, base_offset));
     __ push_d(f10);
     __ j(Done);
@@ -449,8 +444,7 @@ void TemplateTable::ldc2_w()
     __ bne(x12, t1, notLong);
 
     // ltos
-    __ slli(x10, x10, 3);
-    __ add(x10, x11, x10);
+    __ shadd(x10, x10, x11, x10, 3);
     __ ld(x10, Address(x10, base_offset));
     __ push_l(x10);
     __ j(Done);
@@ -754,8 +748,7 @@ void TemplateTable::iaload()
   // x11: index
   index_check(x10, x11); // leaves index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_INT) >> 2);
-  __ slli(t0, x11, 2);
-  __ add(x10, t0, x10);
+  __ shadd(x10, x11, x10, t0, 2);
   __ access_load_at(T_INT, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
   __ addw(x10, x10, zr); // signed extended
 }
@@ -769,8 +762,7 @@ void TemplateTable::laload()
   // x11: index
   index_check(x10, x11); // leaves index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_LONG) >> 3);
-  __ slli(t0, x11, 3);
-  __ add(x10, t0, x10);
+  __ shadd(x10, x11, x10, t0, 3);
   __ access_load_at(T_LONG, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
 }
 
@@ -783,8 +775,7 @@ void TemplateTable::faload()
   // x11: index
   index_check(x10, x11); // leaves index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_FLOAT) >> 2);
-  __ slli(t0, x11, 2);
-  __ add(x10, t0, x10);
+  __ shadd(x10, x11, x10, t0, 2);
   __ access_load_at(T_FLOAT, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
 }
 
@@ -797,8 +788,7 @@ void TemplateTable::daload()
   // x11: index
   index_check(x10, x11); // leaves index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_DOUBLE) >> 3);
-  __ slli(t0, x11, 3);
-  __ add(x10, t0, x10);
+  __ shadd(x10, x11, x10, t0, 3);
   __ access_load_at(T_DOUBLE, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
 }
 
@@ -811,8 +801,7 @@ void TemplateTable::aaload()
   // x11: index
   index_check(x10, x11); // leaves index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
-  __ slli(t0, x11, LogBytesPerHeapOop);
-  __ add(x10, t0, x10);
+  __ shadd(x10, x11, x10, t0, LogBytesPerHeapOop);
   do_oop_load(_masm,
               Address(x10),
               x10,
@@ -828,8 +817,7 @@ void TemplateTable::baload()
   // x11: index
   index_check(x10, x11); // leaves index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_BYTE) >> 0);
-  __ slli(t0, x11, 0);
-  __ add(x10, t0, x10);
+  __ shadd(x10, x11, x10, t0, 0);
   __ access_load_at(T_BYTE, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
 }
 
@@ -842,8 +830,7 @@ void TemplateTable::caload()
   // x11: index
   index_check(x10, x11); // leaves index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_CHAR) >> 1);
-  __ slli(t0, x11, 1);
-  __ add(x10, t0, x10);
+  __ shadd(x10, x11, x10, t0, 1);
   __ access_load_at(T_CHAR, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
 }
 
@@ -860,8 +847,7 @@ void TemplateTable::fast_icaload()
   // x11: index
   index_check(x10, x11); // leaves index in x11, kills t0
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_CHAR) >> 1); // addi, max imm is 2^11
-  __ slli(t0, x11, 1);
-  __ add(x10, x10, t0);
+  __ shadd(x10, x11, x10, t0, 1);
   __ access_load_at(T_CHAR, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
 }
 
@@ -874,8 +860,7 @@ void TemplateTable::saload()
   // x11: index
   index_check(x10, x11); // leaves index in x11, kills t0
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_SHORT) >> 1);
-  __ slli(t0, x11, 1);
-  __ add(x10, t0, x10);
+  __ shadd(x10, x11, x10, t0, 1);
   __ access_load_at(T_SHORT, IN_HEAP | IS_ARRAY, x10, Address(x10), noreg, noreg);
 }
 
@@ -1062,8 +1047,7 @@ void TemplateTable::iastore() {
   // x13: array
   index_check(x13, x11); // prefer index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_INT) >> 2);
-  __ slli(t0, x11, 2);
-  __ add(t0, x13, t0);
+  __ shadd(t0, x11, x13, t0, 2);
   __ access_store_at(T_INT, IN_HEAP | IS_ARRAY, Address(t0, 0), x10, noreg, noreg);
 }
 
@@ -1076,8 +1060,7 @@ void TemplateTable::lastore() {
   // x13: array
   index_check(x13, x11); // prefer index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_LONG) >> 3);
-  __ slli(t0, x11, 3);
-  __ add(t0, x13, t0);
+  __ shadd(t0, x11, x13, t0, 3);
   __ access_store_at(T_LONG, IN_HEAP | IS_ARRAY, Address(t0, 0), x10, noreg, noreg);
 }
 
@@ -1090,8 +1073,7 @@ void TemplateTable::fastore() {
   // x13:  array
   index_check(x13, x11); // prefer index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_FLOAT) >> 2);
-  __ slli(t0, x11, 2);
-  __ add(t0, x13, t0);
+  __ shadd(t0, x11, x13, t0, 2);
   __ access_store_at(T_FLOAT, IN_HEAP | IS_ARRAY, Address(t0, 0), noreg /* ftos */, noreg, noreg);
 }
 
@@ -1104,8 +1086,7 @@ void TemplateTable::dastore() {
   // x13:  array
   index_check(x13, x11); // prefer index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_DOUBLE) >> 3);
-  __ slli(t0, x11, 3);
-  __ add(t0, x13, t0);
+  __ shadd(t0, x11, x13, t0, 3);
   __ access_store_at(T_DOUBLE, IN_HEAP | IS_ARRAY, Address(t0, 0), noreg /* dtos */, noreg, noreg);
 }
 
@@ -1119,8 +1100,7 @@ void TemplateTable::aastore() {
 
   index_check(x13, x12);     // kills x11
   __ add(x14, x12, arrayOopDesc::base_offset_in_bytes(T_OBJECT) >> LogBytesPerHeapOop);
-  __ slli(x14, x14, LogBytesPerHeapOop);
-  __ add(x14, x13, x14);
+  __ shadd(x14, x14, x13, x14, LogBytesPerHeapOop);
 
   Address element_address(x14, 0);
 
@@ -1201,8 +1181,7 @@ void TemplateTable::castore()
   // x13: array
   index_check(x13, x11); // prefer index in x11
   __ add(x11, x11, arrayOopDesc::base_offset_in_bytes(T_CHAR) >> 1);
-  __ slli(t0, x11, 1);
-  __ add(t0, x13, t0);
+  __ shadd(t0, x11, x13, t0, 1);
   __ access_store_at(T_CHAR, IN_HEAP | IS_ARRAY, Address(t0, 0), x10, noreg, noreg);
 }
 
@@ -2015,8 +1994,7 @@ void TemplateTable::tableswitch() {
   __ bgt(x10, x13, default_case);
   // lookup dispatch offset
   __ subw(x10, x10, x12);
-  __ slli(t0, x10, 2);
-  __ add(x13, x11, t0);
+  __ shadd(x13, x10, x11, t0, 2);
   __ lwu(x13, Address(x13, 3 * BytesPerInt));
   __ profile_switch_case(x10, x11, x12);
   // continue execution
@@ -2053,8 +2031,7 @@ void TemplateTable::fast_linearswitch() {
   __ j(loop_entry);
   // table search
   __ bind(loop);
-  __ slli(t0, x11, 3);
-  __ add(t0, x9, t0);
+  __ shadd(t0, x11, x9, t0, 3);
   __ lw(t0, Address(t0, 2 * BytesPerInt));
   __ beq(x10, t0, found);
   __ bind(loop_entry);
@@ -2066,8 +2043,7 @@ void TemplateTable::fast_linearswitch() {
   __ j(continue_execution);
   // entry found -> get offset
   __ bind(found);
-  __ slli(t0, x11, 3);
-  __ add(t0, x9, t0);
+  __ shadd(t0, x11, x9, t0, 3);
   __ lwu(x13, Address(t0, 3 * BytesPerInt));
   __ profile_switch_case(x11, x10, x9);
   // continue execution
@@ -2141,8 +2117,7 @@ void TemplateTable::fast_binaryswitch() {
     // then [j = h]
     // else [i = h]
     // Convert array[h].match to native byte-ordering before compare
-    __ slli(temp, h, 3);
-    __ add(temp, array, temp);
+    __ shadd(temp, h, array, temp, 3);
     __ ld(temp, Address(temp, 0));
     __ revb_w_w(temp, temp); // reverse bytes in word (32bit) and sign-extend
 
@@ -2165,15 +2140,13 @@ void TemplateTable::fast_binaryswitch() {
   // end of binary search, result index is i (must check again!)
   Label default_case;
   // Convert array[i].match to native byte-ordering before compare
-  __ slli(temp, i, 3);
-  __ add(temp, array, temp);
+  __ shadd(temp, i, array, temp, 3);
   __ ld(temp, Address(temp, 0));
   __ revb_w_w(temp, temp); // reverse bytes in word (32bit) and sign-extend
   __ bne(key, temp, default_case);
 
   // entry found -> j = offset
-  __ slli(temp, i, 3);
-  __ add(temp, array, temp);
+  __ shadd(temp, i, array, temp, 3);
   __ lwu(j, Address(temp, BytesPerInt));
   __ profile_switch_case(i, key, array);
   __ revb_w_w(j, j); // reverse bytes in word (32bit) and sign-extend
@@ -3224,8 +3197,7 @@ void TemplateTable::prepare_invoke(int byte_no,
   // load receiver if needed (note: no return address pushed yet)
   if (load_receiver) {
     __ andi(recv, flags, ConstantPoolCacheEntry::parameter_size_mask); // parameter_size_mask = 1 << 8
-    __ slli(t0, recv, 3);
-    __ add(t0, esp, t0);
+    __ shadd(t0, recv, esp, t0, 3);
     __ ld(recv, Address(t0, -Interpreter::expr_offset_in_bytes(1)));
     __ verify_oop(recv);
   }
@@ -3238,8 +3210,7 @@ void TemplateTable::prepare_invoke(int byte_no,
   {
     const address table_addr = (address) Interpreter::invoke_return_entry_table_for(code);
     __ mv(t0, table_addr);
-    __ slli(t1, t1, 3);
-    __ add(t0, t0, t1);
+    __ shadd(t0, t1, t0, t1, 3);
     __ ld(ra, Address(t0, 0));
   }
 }
@@ -3960,8 +3931,7 @@ void TemplateTable::wide()
 {
   __ load_unsigned_byte(x9, at_bcp(1));
   __ mv(t0, (address)Interpreter::_wentry_point);
-  __ slli(t1, x9, 3);
-  __ add(t0, t1, t0);
+  __ shadd(t0, x9, t0, t1, 3);
   __ ld(t0, Address(t0));
   __ jr(t0);
 }
@@ -3972,13 +3942,11 @@ void TemplateTable::multianewarray() {
   __ load_unsigned_byte(x10, at_bcp(3)); // get number of dimensions
   // last dim is on top of stack; we want address of first one:
   // first_addr = last_addr + (ndims - 1) * wordSize
-  __ slli(c_rarg1, x10, 3);
-  __ add(c_rarg1, c_rarg1, esp);
+  __ shadd(c_rarg1, x10, esp, c_rarg1, 3);
   __ sub(c_rarg1, c_rarg1, wordSize);
   call_VM(x10,
           CAST_FROM_FN_PTR(address, InterpreterRuntime::multianewarray),
           c_rarg1);
   __ load_unsigned_byte(x11, at_bcp(3));
-  __ slli(t0, x11, 3);
-  __ add(esp, esp, t0);
+  __ shadd(esp, x11, esp, t0, 3);
 }


### PR DESCRIPTION
This PR implements shift left and add instructions: `sh1add`/`sh2add`/`sh3add`/`sh1add.uw`/`sh2add.uw`/`sh3add.uw`.

New C2 instructions are covered by JTREG test: test/jdk/java/lang

Hotspot and jdk tier1 tests on QEMU (with and without UseRVB) are passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279827](https://bugs.openjdk.java.net/browse/JDK-8279827): riscv: RVB: Add shift and add instructions


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)
 * [Yanhong Zhu](https://openjdk.java.net/census#yzhu) (@yhzhu20 - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/43.diff">https://git.openjdk.java.net/riscv-port/pull/43.diff</a>

</details>
