### PR TITLE
8279914: riscv: Wrong result caused by incorrect use of iregL2I operand in some c2 match rules

### DIFF
--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -6414,7 +6414,7 @@ instruct addP_reg_reg(iRegPNoSp dst, iRegP src1, iRegL src2) %{
 %}
 
 // If we shift more than 32 bits, we need not convert I2L.
-instruct lShiftL_regI_immGE32(iRegLNoSp dst, iRegIorL2I src, uimmI6_ge32 scale) %{
+instruct lShiftL_regI_immGE32(iRegLNoSp dst, iRegI src, uimmI6_ge32 scale) %{
   match(Set dst (LShiftL (ConvI2L src) scale));
   ins_cost(ALU_COST);
   format %{ "slli  $dst, $src, $scale & 63\t#@lShiftL_regI_immGE32" %}
@@ -6589,21 +6589,6 @@ instruct mulI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   ins_pipe(imul_reg_reg);
 %}
 
-instruct smulI(iRegLNoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
-  match(Set dst (MulL (ConvI2L src1) (ConvI2L src2)));
-  ins_cost(IMUL_COST);
-  format %{ "mul  $dst, $src1, $src2\t#@smulI" %}
-
-  // Signed Multiply Long multiplies two 32-bit signed values to produce a 64-bit result.
-  ins_encode %{
-    __ mul(as_Register($dst$$reg),
-            as_Register($src1$$reg),
-            as_Register($src2$$reg));
-  %}
-
-  ins_pipe(imul_reg_reg);
-%}
-
 // Long Multiply
 
 instruct mulL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
@@ -6704,6 +6689,7 @@ instruct modL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 // Integer Shifts
 
 // Shift Left Register
+// In RV64I, only the low 5 bits of rs2 are considered for the shift amount
 instruct lShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (LShiftI src1 src2));
   ins_cost(ALU_COST);
@@ -6736,6 +6722,7 @@ instruct lShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 %}
 
 // Shift Right Logical Register
+// In RV64I, only the low 5 bits of rs2 are considered for the shift amount
 instruct urShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (URShiftI src1 src2));
   ins_cost(ALU_COST);
@@ -6768,6 +6755,7 @@ instruct urShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 %}
 
 // Shift Right Arithmetic Register
+// In RV64I, only the low 5 bits of rs2 are considered for the shift amount
 instruct rShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (RShiftI src1 src2));
   ins_cost(ALU_COST);
@@ -6802,6 +6790,7 @@ instruct rShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 // Long Shifts
 
 // Shift Left Register
+// In RV64I, only the low 6 bits of rs2 are considered for the shift amount
 instruct lShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (LShiftL src1 src2));
 
@@ -6836,6 +6825,7 @@ instruct lShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
 %}
 
 // Shift Right Logical Register
+// In RV64I, only the low 6 bits of rs2 are considered for the shift amount
 instruct urShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (URShiftL src1 src2));
 
@@ -6888,6 +6878,7 @@ instruct urShiftP_reg_imm(iRegLNoSp dst, iRegP src1, immI src2) %{
 %}
 
 // Shift Right Arithmetic Register
+// In RV64I, only the low 6 bits of rs2 are considered for the shift amount
 instruct rShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (RShiftL src1 src2));
 
@@ -6921,8 +6912,7 @@ instruct rShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
   ins_pipe(ialu_reg_shift);
 %}
 
-instruct regI_not_reg(iRegINoSp dst,
-                         iRegIorL2I src1, immI_M1 m1) %{
+instruct regI_not_reg(iRegINoSp dst, iRegI src1, immI_M1 m1) %{
   match(Set dst (XorI src1 m1));
   ins_cost(ALU_COST);
   format %{ "xori  $dst, $src1, -1\t#@regI_not_reg" %}
@@ -6934,8 +6924,7 @@ instruct regI_not_reg(iRegINoSp dst,
   ins_pipe(ialu_reg);
 %}
 
-instruct regL_not_reg(iRegLNoSp dst,
-                      iRegL src1, immL_M1 m1) %{
+instruct regL_not_reg(iRegLNoSp dst, iRegL src1, immL_M1 m1) %{
   match(Set dst (XorL src1 m1));
   ins_cost(ALU_COST);
   format %{ "xori  $dst, $src1, -1\t#@regL_not_reg" %}
@@ -7369,7 +7358,7 @@ instruct sqrtD_reg(fRegD dst, fRegD src) %{
 // Logical Instructions
 
 // Register And
-instruct andI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+instruct andI_reg_reg(iRegINoSp dst, iRegI src1, iRegI src2) %{
   match(Set dst (AndI src1 src2));
 
   format %{ "andr  $dst, $src1, $src2\t#@andI_reg_reg" %}
@@ -7385,7 +7374,7 @@ instruct andI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
 %}
 
 // Immediate And
-instruct andI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immIAdd src2) %{
+instruct andI_reg_imm(iRegINoSp dst, iRegI src1, immIAdd src2) %{
   match(Set dst (AndI src1 src2));
 
   format %{ "andi  $dst, $src1, $src2\t#@andI_reg_imm" %}
@@ -7401,7 +7390,7 @@ instruct andI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immIAdd src2) %{
 %}
 
 // Register Or
-instruct orI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+instruct orI_reg_reg(iRegINoSp dst, iRegI src1, iRegI src2) %{
   match(Set dst (OrI src1 src2));
 
   format %{ "orr  $dst, $src1, $src2\t#@orI_reg_reg" %}
@@ -7417,7 +7406,7 @@ instruct orI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
 %}
 
 // Immediate Or
-instruct orI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immIAdd src2) %{
+instruct orI_reg_imm(iRegINoSp dst, iRegI src1, immIAdd src2) %{
   match(Set dst (OrI src1 src2));
 
   format %{ "ori  $dst, $src1, $src2\t#@orI_reg_imm" %}
@@ -7433,7 +7422,7 @@ instruct orI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immIAdd src2) %{
 %}
 
 // Register Xor
-instruct xorI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
+instruct xorI_reg_reg(iRegINoSp dst, iRegI src1, iRegI src2) %{
   match(Set dst (XorI src1 src2));
 
   format %{ "xorr  $dst, $src1, $src2\t#@xorI_reg_reg" %}
@@ -7449,7 +7438,7 @@ instruct xorI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
 %}
 
 // Immediate Xor
-instruct xorI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immIAdd src2) %{
+instruct xorI_reg_imm(iRegINoSp dst, iRegI src1, immIAdd src2) %{
   match(Set dst (XorI src1 src2));
 
   format %{ "xori  $dst, $src1, $src2\t#@xorI_reg_imm" %}
@@ -7841,7 +7830,7 @@ instruct castVV(vReg dst)
 // Convert Instructions
 
 // int to bool
-instruct convI2Bool(iRegINoSp dst, iRegIorL2I src)
+instruct convI2Bool(iRegINoSp dst, iRegI src)
 %{
   match(Set dst (Conv2B src));
 
@@ -7877,7 +7866,7 @@ instruct convI2L_reg_reg(iRegLNoSp dst, iRegIorL2I src)
   match(Set dst (ConvI2L src));
 
   ins_cost(ALU_COST);
-  format %{ "addw  $dst, $src\t#@convI2L_reg_reg" %}
+  format %{ "addw  $dst, $src, zr\t#@convI2L_reg_reg" %}
   ins_encode %{
     __ addw(as_Register($dst$$reg), as_Register($src$$reg), zr);
   %}
@@ -8437,7 +8426,7 @@ instruct cmpL3_reg_reg(iRegINoSp dst, iRegL op1, iRegL op2)
   ins_pipe(pipe_class_default);
 %}
 
-instruct cmpLTMask_reg_reg(iRegINoSp dst, iRegIorL2I p, iRegIorL2I q)
+instruct cmpLTMask_reg_reg(iRegINoSp dst, iRegI p, iRegI q)
 %{
   match(Set dst (CmpLTMask p q));
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -6689,7 +6689,7 @@ instruct modL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
 // Integer Shifts
 
 // Shift Left Register
-// In RV64I, only the low 5 bits of rs2 are considered for the shift amount
+// In RV64I, only the low 5 bits of src2 are considered for the shift amount
 instruct lShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (LShiftI src1 src2));
   ins_cost(ALU_COST);
@@ -6722,7 +6722,7 @@ instruct lShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 %}
 
 // Shift Right Logical Register
-// In RV64I, only the low 5 bits of rs2 are considered for the shift amount
+// In RV64I, only the low 5 bits of src2 are considered for the shift amount
 instruct urShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (URShiftI src1 src2));
   ins_cost(ALU_COST);
@@ -6755,7 +6755,7 @@ instruct urShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 %}
 
 // Shift Right Arithmetic Register
-// In RV64I, only the low 5 bits of rs2 are considered for the shift amount
+// In RV64I, only the low 5 bits of src2 are considered for the shift amount
 instruct rShiftI_reg_reg(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   match(Set dst (RShiftI src1 src2));
   ins_cost(ALU_COST);
@@ -6790,7 +6790,7 @@ instruct rShiftI_reg_imm(iRegINoSp dst, iRegIorL2I src1, immI src2) %{
 // Long Shifts
 
 // Shift Left Register
-// In RV64I, only the low 6 bits of rs2 are considered for the shift amount
+// In RV64I, only the low 6 bits of src2 are considered for the shift amount
 instruct lShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (LShiftL src1 src2));
 
@@ -6825,7 +6825,7 @@ instruct lShiftL_reg_imm(iRegLNoSp dst, iRegL src1, immI src2) %{
 %}
 
 // Shift Right Logical Register
-// In RV64I, only the low 6 bits of rs2 are considered for the shift amount
+// In RV64I, only the low 6 bits of src2 are considered for the shift amount
 instruct urShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (URShiftL src1 src2));
 
@@ -6878,7 +6878,7 @@ instruct urShiftP_reg_imm(iRegLNoSp dst, iRegP src1, immI src2) %{
 %}
 
 // Shift Right Arithmetic Register
-// In RV64I, only the low 6 bits of rs2 are considered for the shift amount
+// In RV64I, only the low 6 bits of src2 are considered for the shift amount
 instruct rShiftL_reg_reg(iRegLNoSp dst, iRegL src1, iRegIorL2I src2) %{
   match(Set dst (RShiftL src1 src2));
 

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -904,7 +904,7 @@ instruct reduce_addD(fRegD src1_dst, vReg src2, vReg tmp) %{
 %}
 
 // vector integer max reduction
-instruct vreduce_maxB(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct vreduce_maxB(iRegINoSp dst, iRegI src1, vReg src2, vReg tmp) %{
   predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
   match(Set dst (MaxReductionV src1 src2));
   ins_cost(VEC_COST);
@@ -922,7 +922,7 @@ instruct vreduce_maxB(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vreduce_maxS(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct vreduce_maxS(iRegINoSp dst, iRegI src1, vReg src2, vReg tmp) %{
   predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_SHORT);
   match(Set dst (MaxReductionV src1 src2));
   ins_cost(VEC_COST);
@@ -971,7 +971,7 @@ instruct vreduce_maxL(iRegLNoSp dst, iRegL src1, vReg src2, vReg tmp) %{
 %}
 
 // vector integer min reduction
-instruct vreduce_minB(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct vreduce_minB(iRegINoSp dst, iRegI src1, vReg src2, vReg tmp) %{
   predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_BYTE);
   match(Set dst (MinReductionV src1 src2));
   ins_cost(VEC_COST);
@@ -989,7 +989,7 @@ instruct vreduce_minB(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct vreduce_minS(iRegINoSp dst, iRegIorL2I src1, vReg src2, vReg tmp) %{
+instruct vreduce_minS(iRegINoSp dst, iRegI src1, vReg src2, vReg tmp) %{
   predicate(n->in(2)->bottom_type()->is_vect()->element_basic_type() == T_SHORT);
   match(Set dst (MinReductionV src1 src2));
   ins_cost(VEC_COST);


### PR DESCRIPTION
This PR fixes the issue that incorrect use of iRegL2I operand in some c2 match rules.

Test on [JDK-8279914](https://bugs.openjdk.java.net/browse/JDK-8279914) passed after this fixing.

Hotspot tier1 test on QEMU are passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279914](https://bugs.openjdk.java.net/browse/JDK-8279914): riscv: Wrong result caused by incorrect use of iregL2I operand in some c2 match rules


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/44.diff">https://git.openjdk.java.net/riscv-port/pull/44.diff</a>

</details>
