### PR TITLE
8279826: riscv: Preserve result in native wrapper with +UseHeavyMonitors

### DIFF
--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -1643,13 +1643,15 @@ nmethod* SharedRuntime::generate_native_wrapper(MacroAssembler* masm,
       // Simple recursive lock?
       __ ld(t0, Address(sp, lock_slot_offset * VMRegImpl::stack_slot_size));
       __ beqz(t0, done);
-
-      // Must save x10 if if it is live now because cmpxchg must use it
-      if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
-        save_native_result(masm, ret_type, stack_slots);
-      }
+    }
 
 
+    // Must save x10 if if it is live now because cmpxchg must use it
+    if (ret_type != T_FLOAT && ret_type != T_DOUBLE && ret_type != T_VOID) {
+      save_native_result(masm, ret_type, stack_slots);
+    }
+
+    if (!UseHeavyMonitors) {
       // get address of the stack lock
       __ la(x10, Address(sp, lock_slot_offset * VMRegImpl::stack_slot_size));
       //  get old displaced header


### PR DESCRIPTION
Testing observed a few failures after JDK-8278387. On RISC-V, we followed JDK-8278489: The reason for the failures is in the native-wrappers, in the +UseHeavyMonitors paths, we don't preserve the result register after the native call.

Hotspot/jdk tier1 passed on the unmatched with -XX:+UseHeavyMonitors, and all jtregs were tested on Qemu without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279826](https://bugs.openjdk.java.net/browse/JDK-8279826): riscv: Preserve result in native wrapper with +UseHeavyMonitors


### Reviewers
 * [Feilong Jiang](https://openjdk.java.net/census#fjiang) (@feilongjiang - Author)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/46.diff">https://git.openjdk.java.net/riscv-port/pull/46.diff</a>

</details>
