### PR TITLE
8280236: riscv: Minimal build failed after JDK-8279565

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -136,9 +136,9 @@ class MacroAssembler: public Assembler {
   void super_call_VM_leaf(address entry_point, Register arg_0, Register arg_1, Register arg_2, Register arg_3);
 
   // last Java Frame (fills frame anchor)
-  void set_last_Java_frame(Register last_java_sp, Register last_java_fp, address last_java_pc, Register temp);
-  void set_last_Java_frame(Register last_java_sp, Register last_java_fp, Label &last_java_pc, Register temp);
-  void set_last_Java_frame(Register last_java_sp, Register last_java_fp, Register last_java_pc,Register temp);
+  void set_last_Java_frame(Register last_java_sp, Register last_java_fp, address last_java_pc, Register tmp);
+  void set_last_Java_frame(Register last_java_sp, Register last_java_fp, Label &last_java_pc, Register tmp);
+  void set_last_Java_frame(Register last_java_sp, Register last_java_fp, Register last_java_pc, Register tmp);
 
   // thread in the default location (xthread)
   void reset_last_Java_frame(bool clear_fp);
@@ -248,7 +248,7 @@ class MacroAssembler: public Assembler {
                                Register intf_klass,
                                RegisterOrConstant itable_index,
                                Register method_result,
-                               Register scan_temp,
+                               Register scan_tmp,
                                Label& no_such_interface,
                                bool return_method = true);
 
@@ -288,10 +288,10 @@ class MacroAssembler: public Assembler {
   // The fast path produces a tri-state answer: yes / no / maybe-slow.
   // One of the three labels can be NULL, meaning take the fall-through.
   // If super_check_offset is -1, the value is loaded up from super_klass.
-  // No registers are killed, except temp_reg
+  // No registers are killed, except tmp_reg
   void check_klass_subtype_fast_path(Register sub_klass,
                                      Register super_klass,
-                                     Register temp_reg,
+                                     Register tmp_reg,
                                      Label* L_success,
                                      Label* L_failure,
                                      Label* L_slow_path,
@@ -299,18 +299,18 @@ class MacroAssembler: public Assembler {
 
   // The reset of the type cehck; must be wired to a corresponding fast path.
   // It does not repeat the fast path logic, so don't use it standalone.
-  // The temp_reg and temp2_reg can be noreg, if no temps are avaliable.
+  // The tmp1_reg and tmp2_reg can be noreg, if no temps are avaliable.
   // Updates the sub's secondary super cache as necessary.
   void check_klass_subtype_slow_path(Register sub_klass,
                                      Register super_klass,
-                                     Register temp_reg,
-                                     Register temp2_reg,
+                                     Register tmp1_reg,
+                                     Register tmp2_reg,
                                      Label* L_success,
                                      Label* L_failure);
 
   void check_klass_subtype(Register sub_klass,
                            Register super_klass,
-                           Register temp_reg,
+                           Register tmp_reg,
                            Label& L_success);
 
   Address argument_address(RegisterOrConstant arg_slot, int extra_slot_offset = 0);
@@ -537,7 +537,8 @@ class MacroAssembler: public Assembler {
   void revb_w(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2= t1);         // reverse bytes in each word
   void revb(Register Rd, Register Rs, Register tmp1 = t0, Register tmp2 = t1);          // reverse bytes in doubleword
 
-  void andi(Register Rd, Register Rn, int64_t increment, Register temp = t0);
+  void ror_imm(Register dst, Register src, uint32_t shift, Register tmp = t0);
+  void andi(Register Rd, Register Rn, int64_t imm, Register tmp = t0);
   void orptr(Address adr, RegisterOrConstant src, Register tmp1 = t0, Register tmp2 = t1);
 
   void cmpxchg_obj_header(Register oldv, Register newv, Register obj, Register tmp, Label &succeed, Label *fail);
@@ -650,7 +651,6 @@ class MacroAssembler: public Assembler {
   void adc(Register dst, Register src1, Register src2, Register carry);
   void add2_with_carry(Register final_dest_hi, Register dest_hi, Register dest_lo,
                        Register src1, Register src2, Register carry);
-  void ror_imm(Register dst, Register src, uint32_t shift, Register tmp = t0);
   void multiply_32_x_32_loop(Register x, Register xstart, Register x_xstart,
                              Register y, Register y_idx, Register z,
                              Register carry, Register product,
@@ -688,10 +688,10 @@ class MacroAssembler: public Assembler {
   // e.g. convert from NaN, +Inf, -Inf to int, float, double
   // will trigger exception, we need to deal with these situations
   // to get correct results.
-  void fcvt_w_s_safe(Register dst, FloatRegister src, Register temp = t0);
-  void fcvt_l_s_safe(Register dst, FloatRegister src, Register temp = t0);
-  void fcvt_w_d_safe(Register dst, FloatRegister src, Register temp = t0);
-  void fcvt_l_d_safe(Register dst, FloatRegister src, Register temp = t0);
+  void fcvt_w_s_safe(Register dst, FloatRegister src, Register tmp = t0);
+  void fcvt_l_s_safe(Register dst, FloatRegister src, Register tmp = t0);
+  void fcvt_w_d_safe(Register dst, FloatRegister src, Register tmp = t0);
+  void fcvt_l_d_safe(Register dst, FloatRegister src, Register tmp = t0);
 
   // vector load/store unit-stride instructions
   void vlex_v(VectorRegister vd, Register base, Assembler::SEW sew, VectorMask vm = unmasked) {
@@ -796,7 +796,7 @@ private:
     lbl.reset();
   }
 #endif
-  void repne_scan(Register addr, Register value, Register count, Register temp);
+  void repne_scan(Register addr, Register value, Register count, Register tmp);
 
   // Return true if an address is within the 48-bit RISCV64 address space.
   bool is_valid_riscv64_address(address addr) {


### PR DESCRIPTION
After JDK-8279565, minimal build complains `'ror_imm' was not declared in this scope` error. The definition of `ror_imm` should move outside of the`COMPILER2` macro.

With this patch, minimal build passed without errors.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280236](https://bugs.openjdk.java.net/browse/JDK-8280236): riscv: Minimal build failed after JDK-8279565


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/48.diff">https://git.openjdk.java.net/riscv-port/pull/48.diff</a>

</details>
