### PR TITLE
8279664: riscv: JFR crashes at 0x0

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -51,7 +51,9 @@ class MacroAssembler: public Assembler {
   // Alignment
   void align(int modulus, int extra_offset = 0);
 
-  // Stack frame creation/removal
+  // Stack frame creation/removal:
+  // SP must be updated to the right place before saving/restoring RA and FP because signal
+  // based thread suspend/resume could happen asynchronously.
   void enter() {
     addi(sp, sp, - 2 * wordSize);
     sd(ra, Address(sp, wordSize));
@@ -60,8 +62,6 @@ class MacroAssembler: public Assembler {
   }
 
   void leave() {
-    // Note: setting sp above the address of alive variables could result in undefined behaviors:
-    //   signals could happen at any time, and sig handlers will crash alive variables below sp.
     addi(sp, fp, - 2 * wordSize);
     ld(fp, Address(sp));
     ld(ra, Address(sp, wordSize));

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -51,9 +51,9 @@ class MacroAssembler: public Assembler {
   // Alignment
   void align(int modulus, int extra_offset = 0);
 
-  // Stack frame creation/removal:
-  // SP must be updated to the right place before saving/restoring RA and FP because signal
-  // based thread suspend/resume could happen asynchronously.
+  // Stack frame creation/removal
+  // Note that SP must be updated to the right place before saving/restoring RA and FP
+  // because signal based thread suspend/resume could happen asynchronously.
   void enter() {
     addi(sp, sp, - 2 * wordSize);
     sd(ra, Address(sp, wordSize));

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -60,9 +60,12 @@ class MacroAssembler: public Assembler {
   }
 
   void leave() {
-    mv(sp, fp);
-    ld(fp, Address(sp, -2 * wordSize));
-    ld(ra, Address(sp, -wordSize));
+    // Note: setting sp above the address of alive variables could result in undefined behaviors:
+    //   signals could happen at any time, and sig handlers will crash alive variables below sp.
+    addi(sp, fp, - 2 * wordSize);
+    ld(fp, Address(sp));
+    ld(ra, Address(sp, wordSize));
+    addi(sp, sp, 2 * wordSize);
   }
 
 


### PR DESCRIPTION
Hi team,

This is a preview fix for the JFR-related crash - maybe the comment in this patch should be polished.
TIL that complex problems often result from seemingly negligible changes :-)
I need to cautiously test this change, though it seems no harm, to guarantee that it is safe and to ensure the problem is gone so please stay a little tuned.

----
Update:

1. Overnight JFR testing reveals no error, seems fixed.
2. `test/hotspot/jtreg` on the board reveals no error until now - still testing, but I think it is safe.
----

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8279664](https://bugs.openjdk.java.net/browse/JDK-8279664): riscv: JFR crashes at 0x0


### Reviewers
 * [Yadong Wang](https://openjdk.java.net/census#yadongwang) (@yadongw - Committer) ⚠️ Review applies to 7c7a1426470b8f81b0ad71913f968baaaf92d079
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/49.diff">https://git.openjdk.java.net/riscv-port/pull/49.diff</a>

</details>
