### PR TITLE
8280424: riscv: fix saved_fp for compiled frame in frame::safe_for_sender

### DIFF
--- a/src/hotspot/cpu/riscv/c1_FrameMap_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_FrameMap_riscv.cpp
@@ -330,7 +330,7 @@ Address FrameMap::make_new_address(ByteSize sp_offset) const {
 
 
 // ----------------mapping-----------------------
-// all mapping is based on rfp addressing, except for simple leaf methods where we access
+// all mapping is based on fp addressing, except for simple leaf methods where we access
 // the locals sp based (and no frame is built)
 
 
@@ -351,7 +351,7 @@ Address FrameMap::make_new_address(ByteSize sp_offset) const {
 //   +----------+
 //   | ret addr |
 //   +----------+
-//   |  args    |  <- RFP
+//   |  args    |  <- FP
 //   | .........|
 
 

--- a/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
+++ b/src/jdk.hotspot.agent/share/classes/sun/jvm/hotspot/runtime/riscv64/RISCV64Frame.java
@@ -387,11 +387,11 @@ public class RISCV64Frame extends Frame {
     Address senderSP = getUnextendedSP().addOffsetTo(cb.getFrameSize());
 
     // The return_address is always the word on the stack
-    Address senderPC = senderSP.getAddressAt(-1 * VM.getVM().getAddressSize());
+    Address senderPC = senderSP.getAddressAt(RETURN_ADDR_OFFSET * VM.getVM().getAddressSize());
 
     // This is the saved value of FP which may or may not really be an FP.
     // It is only an FP if the sender is an interpreter frame.
-    Address savedFPAddr = senderSP.addOffsetTo(- SENDER_SP_OFFSET * VM.getVM().getAddressSize());
+    Address savedFPAddr = senderSP.addOffsetTo(LINK_OFFSET * VM.getVM().getAddressSize());
 
     if (map.getUpdateMap()) {
       // Tell GC to use argument oopmaps for some runtime stubs that need it.


### PR DESCRIPTION
Some places are missed updating when refactoring riscv stack frame previously.

We need to update calculation of saved_fp for compiled frame in frame::safe_for_sender.

Previous riscv stack frame patch:
https://github.com/openjdk/jdk-sandbox/commit/db2415748747a0912749bb8fc160a8948021a924

All jtregs were tested on QEMU without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280424](https://bugs.openjdk.java.net/browse/JDK-8280424): riscv: fix saved_fp for compiled frame in frame::safe_for_sender


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/52.diff">https://git.openjdk.java.net/riscv-port/pull/52.diff</a>

</details>
