### PR TITLE
8280497: riscv: Undefined Behaviour in class Assembler

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -43,7 +43,7 @@ class Argument {
     n_int_register_parameters_c   = 8, // x10, x11, ... x17 (c_rarg0, c_rarg1, ...)
     n_float_register_parameters_c = 8, // f10, f11, ... f17 (c_farg0, c_farg1, ... )
 
-    n_int_register_parameters_j   = 8, // x11, ... x17, x10 (rj_rarg0, j_rarg1, ...)
+    n_int_register_parameters_j   = 8, // x11, ... x17, x10 (j_rarg0, j_rarg1, ...)
     n_float_register_parameters_j = 8  // f10, f11, ... f17 (j_farg0, j_farg1, ...)
   };
 };

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -40,8 +40,8 @@
 class Argument {
  public:
   enum {
-    n_int_register_parameters_c   = 8,  // x10, x11, ... x17 (c_rarg0, c_rarg1, ...)
-    n_float_register_parameters_c = 8,  // f10, f11, ... f17 (c_farg0, c_farg1, ... )
+    n_int_register_parameters_c   = 8, // x10, x11, ... x17 (c_rarg0, c_rarg1, ...)
+    n_float_register_parameters_c = 8, // f10, f11, ... f17 (c_farg0, c_farg1, ... )
 
     n_int_register_parameters_j   = 8, // x11, ... x17, x10 (rj_rarg0, j_rarg1, ...)
     n_float_register_parameters_j = 8  // f10, f11, ... f17 (j_farg0, j_farg1, ...)
@@ -127,7 +127,7 @@ REGISTER_DECLARATION(Register, xdispatch, x21);
 // Java stack pointer
 REGISTER_DECLARATION(Register, esp,       x20);
 
-// tempory register(caller-save registers)
+// temporary register(caller-save registers)
 REGISTER_DECLARATION(Register, t0, x5);
 REGISTER_DECLARATION(Register, t1, x6);
 REGISTER_DECLARATION(Register, t2, x7);

--- a/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/gc/z/zBarrierSetAssembler_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -221,8 +221,8 @@ class ZSaveLiveRegisters {
 private:
   MacroAssembler* const _masm;
   RegSet                _gp_regs;
-  RegSet                _fp_regs;
-  RegSet                _vp_regs;
+  FloatRegSet           _fp_regs;
+  VectorRegSet          _vp_regs;
 
 public:
   void initialize(ZLoadBarrierStubC2* stub) {
@@ -235,10 +235,10 @@ public:
         if (vm_reg->is_Register()) {
           _gp_regs += RegSet::of(vm_reg->as_Register());
         } else if (vm_reg->is_FloatRegister()) {
-          _fp_regs += RegSet::of((Register)vm_reg->as_FloatRegister());
+          _fp_regs += FloatRegSet::of(vm_reg->as_FloatRegister());
         } else if (vm_reg->is_VectorRegister()) {
           const VMReg vm_reg_base = OptoReg::as_VMReg(opto_reg & ~(VectorRegisterImpl::max_slots_per_register - 1));
-          _vp_regs += RegSet::of((Register)vm_reg_base->as_VectorRegister());
+          _vp_regs += VectorRegSet::of(vm_reg_base->as_VectorRegister());
         } else {
           fatal("Unknown register type");
         }

--- a/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globalDefinitions_riscv.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2015, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -46,5 +46,7 @@ const bool CCallingConventionRequiresIntsAsLongs = false;
 #define SUPPORT_RESERVED_STACK_AREA
 
 #define COMPRESSED_CLASS_POINTERS_DEPENDS_ON_COMPRESSED_OOPS false
+
+#define USE_POINTERS_TO_REGISTER_IMPL_ARRAY
 
 #endif // CPU_RISCV_GLOBALDEFINITIONS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -482,11 +482,11 @@ class MacroAssembler: public Assembler {
   void pop_reg(Register Rd);
   int  push_reg(unsigned int bitset, Register stack);
   int  pop_reg(unsigned int bitset, Register stack);
-  void push_fp(RegSet regs, Register stack) { if (regs.bits()) push_fp(regs.bits(), stack); }
-  void pop_fp(RegSet regs, Register stack) { if (regs.bits()) pop_fp(regs.bits(), stack); }
+  void push_fp(FloatRegSet regs, Register stack) { if (regs.bits()) push_fp(regs.bits(), stack); }
+  void pop_fp(FloatRegSet regs, Register stack) { if (regs.bits()) pop_fp(regs.bits(), stack); }
 #ifdef COMPILER2
-  void push_vp(RegSet regs, Register stack) { if (regs.bits()) push_vp(regs.bits(), stack); }
-  void pop_vp(RegSet regs, Register stack) { if (regs.bits()) pop_vp(regs.bits(), stack); }
+  void push_vp(VectorRegSet regs, Register stack) { if (regs.bits()) push_vp(regs.bits(), stack); }
+  void pop_vp(VectorRegSet regs, Register stack) { if (regs.bits()) pop_vp(regs.bits(), stack); }
 #endif // COMPILER2
 
   // Push and pop everything that might be clobbered by a native
@@ -776,6 +776,7 @@ class MacroAssembler: public Assembler {
 
   int push_fp(unsigned int bitset, Register stack);
   int pop_fp(unsigned int bitset, Register stack);
+
   int push_vp(unsigned int bitset, Register stack);
   int pop_vp(unsigned int bitset, Register stack);
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1997, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2018, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -518,10 +518,10 @@ inline bool is_NativeCallTrampolineStub_at(address addr) {
   // 3). check if the offset in ld[31:20] equals the data_offset
   assert_cond(addr != NULL);
   if (NativeInstruction::is_auipc_at(addr) && NativeInstruction::is_ld_at(addr + 4) && NativeInstruction::is_jalr_at(addr + 8) &&
-      ((Register)(intptr_t)Assembler::extract(((unsigned*)addr)[0], 11, 7)     == x5) &&
-      ((Register)(intptr_t)Assembler::extract(((unsigned*)addr)[1], 11, 7)     == x5) &&
-      ((Register)(intptr_t)Assembler::extract(((unsigned*)addr)[1], 19, 15)    == x5) &&
-      ((Register)(intptr_t)Assembler::extract(((unsigned*)addr)[2], 19, 15)    == x5) &&
+      (as_Register((intptr_t)Assembler::extract(((unsigned*)addr)[0], 11, 7))     == x5) &&
+      (as_Register((intptr_t)Assembler::extract(((unsigned*)addr)[1], 11, 7))     == x5) &&
+      (as_Register((intptr_t)Assembler::extract(((unsigned*)addr)[1], 19, 15))    == x5) &&
+      (as_Register((intptr_t)Assembler::extract(((unsigned*)addr)[2], 19, 15))    == x5) &&
       (Assembler::extract(((unsigned*)addr)[1], 31, 20) == NativeCallTrampolineStub::data_offset)) {
     return true;
   }

--- a/src/hotspot/cpu/riscv/register_riscv.cpp
+++ b/src/hotspot/cpu/riscv/register_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,6 +26,10 @@
 #include "precompiled.hpp"
 #include "register_riscv.hpp"
 
+REGISTER_IMPL_DEFINITION(Register, RegisterImpl, RegisterImpl::number_of_registers);
+REGISTER_IMPL_DEFINITION(FloatRegister, FloatRegisterImpl, FloatRegisterImpl::number_of_registers);
+REGISTER_IMPL_DEFINITION(VectorRegister, VectorRegisterImpl, VectorRegisterImpl::number_of_registers);
+
 const int ConcreteRegisterImpl::max_gpr = RegisterImpl::number_of_registers *
                                           RegisterImpl::max_slots_per_register;
 const int ConcreteRegisterImpl::max_fpr =
@@ -38,8 +42,8 @@ const int ConcreteRegisterImpl::max_vpr =
 
 
 const char* RegisterImpl::name() const {
-  const char* names[number_of_registers] = {
-    "zr", "ra", "sp", "gp", "tp", "x5", "x6", "x7", "fp", "x9",
+  static const char *const names[number_of_registers] = {
+    "zr", "ra", "sp", "gp", "tp", "t0", "t1", "t2", "fp", "x9",
     "c_rarg0", "c_rarg1", "c_rarg2", "c_rarg3", "c_rarg4", "c_rarg5", "c_rarg6", "c_rarg7",
     "x18", "x19", "esp", "xdispatch", "xbcp", "xthread", "xlocals",
     "xmonitors", "xcpool", "xheapbase", "x28", "x29", "x30", "xmethod"
@@ -48,7 +52,7 @@ const char* RegisterImpl::name() const {
 }
 
 const char* FloatRegisterImpl::name() const {
-  const char* names[number_of_registers] = {
+  static const char *const names[number_of_registers] = {
     "f0", "f1", "f2", "f3", "f4", "f5", "f6", "f7",
     "f8", "f9", "f10", "f11", "f12", "f13", "f14", "f15",
     "f16", "f17", "f18", "f19", "f20", "f21", "f22", "f23",
@@ -58,7 +62,7 @@ const char* FloatRegisterImpl::name() const {
 }
 
 const char* VectorRegisterImpl::name() const {
-  const char* names[number_of_registers] = {
+  static const char *const names[number_of_registers] = {
     "v0", "v1", "v2", "v3", "v4", "v5", "v6", "v7",
     "v8", "v9", "v10", "v11", "v12", "v13", "v14", "v15",
     "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",

--- a/src/hotspot/cpu/riscv/vmreg_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/vmreg_riscv.inline.hpp
@@ -26,19 +26,19 @@
 #ifndef CPU_RISCV_VM_VMREG_RISCV_INLINE_HPP
 #define CPU_RISCV_VM_VMREG_RISCV_INLINE_HPP
 
-inline VMReg RegisterImpl::as_VMReg() {
+inline VMReg RegisterImpl::as_VMReg() const {
   if (this == noreg) {
     return VMRegImpl::Bad();
   }
   return VMRegImpl::as_VMReg(encoding() * RegisterImpl::max_slots_per_register);
 }
 
-inline VMReg FloatRegisterImpl::as_VMReg() {
+inline VMReg FloatRegisterImpl::as_VMReg() const {
   return VMRegImpl::as_VMReg((encoding() * FloatRegisterImpl::max_slots_per_register) +
                              ConcreteRegisterImpl::max_gpr);
 }
 
-inline VMReg VectorRegisterImpl::as_VMReg() {
+inline VMReg VectorRegisterImpl::as_VMReg() const {
   return VMRegImpl::as_VMReg((encoding() * VectorRegisterImpl::max_slots_per_register) +
                              ConcreteRegisterImpl::max_fpr);
 }


### PR DESCRIPTION
The same problem exists on the riscv platfom. So we follow https://bugs.openjdk.java.net/browse/JDK-8276563.
```
All instances of type Register exhibit UB in the form of wild pointer (including null pointer) dereferences. This isn't very hard to fix: we should make Registers pointer to something rather than aliases of small integers.
```
Hotspot/jdk tier1 were passed on the unmatched board. And all jtreg tests have been tested on Qemu without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280497](https://bugs.openjdk.java.net/browse/JDK-8280497): riscv: Undefined Behaviour in class Assembler


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.java.net/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/53.diff">https://git.openjdk.java.net/riscv-port/pull/53.diff</a>

</details>
