### PR TITLE
8278847: riscv: Intrinsify BigInteger.montgomeryMultiply

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -199,6 +199,10 @@ void VM_Version::c2_initialize() {
   if (FLAG_IS_DEFAULT(UseSquareToLenIntrinsic)) {
     FLAG_SET_DEFAULT(UseSquareToLenIntrinsic, true);
   }
+
+  if (FLAG_IS_DEFAULT(UseMontgomeryMultiplyIntrinsic)) {
+    FLAG_SET_DEFAULT(UseMontgomeryMultiplyIntrinsic, true);
+  }
 }
 #endif // COMPILER2
 


### PR DESCRIPTION
Intrinsify BigInteger.montgomeryMultiply on RISCV.
On unmatched borad, performance of SPECjvm2008 crypto has improved by 4%，of which sub-testcase crypto.rsa has improved by 7%.The details are as follows：

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:\Users\Z00540~1\AppData\Local\Temp\msohtmlclip1\01\clip.htm">
<link rel=File-List
href="file:///C:\Users\Z00540~1\AppData\Local\Temp\msohtmlclip1\01\clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{mso-header-data:"&C&\0022Times New Roman\,Regular\0022&12&A";
	mso-footer-data:"&C&\0022Times New Roman\,Regular\0022&12Page &P";
	margin:1.05in .79in 1.05in .79in;
	mso-header-margin:.79in;
	mso-footer-margin:.79in;
	mso-page-numbers-start:1;}
.font5
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:宋体;
	mso-generic-font-family:auto;
	mso-font-charset:134;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:windowtext;
	font-size:10.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{mso-number-format:"\0022TRUE\0022\;\0022TRUE\0022\;\0022FALSE\0022";
	text-align:center;}
.xl64
	{text-align:right;}
.xl65
	{mso-number-format:Fixed;}
.xl66
	{mso-number-format:Percent;}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:宋体;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->

</head>

<body link="#0563C1" vlink="#954F72">



TRUE(ops/m) | 1 | 2 | 3 | geomean | percent(true/false)
-- | -- | -- | -- | -- | --
crypto.aes | 6.15 | 6.26 | 5.82 | 6.07 | 102.81%
crypto.rsa | 73.07 | 72.77 | 69.5 | 71.76 | 107.22%
crypto.signverify | 56.82 | 57.13 | 56.34 | 56.76 | 102.59%
crypto | 29.44 | 29.63 | 28.35 | 29.13 | 104.18%
**FALSE(ops/m)** |   |   |   |   | 
crypto.aes | 5.77 | 6.14 | 5.82 | 5.91 |  
crypto.rsa | 67.09 | 67.26 | 66.44 | 66.93 |  
crypto.signverify | 55.51 | 55.6 | 54.88 | 55.33 |  
crypto | 27.8 | 28.42 | 27.68 | 27.96 |  



</body>

</html>
All jtregs were tested on QEMU without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8278847](https://bugs.openjdk.java.net/browse/JDK-8278847): riscv: Intrinsify BigInteger.montgomeryMultiply


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/54.diff">https://git.openjdk.java.net/riscv-port/pull/54.diff</a>

</details>
