### PR TITLE
8280683: riscv: Remove uses of long and unsigned long

### DIFF
--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -166,18 +166,11 @@ class Address {
     : _base(noreg), _index(noreg), _offset(0), _mode(no_mode), _target(NULL) { }
   Address(Register r)
     : _base(r),     _index(noreg), _offset(0), _mode(base_plus_offset), _target(NULL) { }
-  Address(Register r, int o)
-    : _base(r),     _index(noreg), _offset(o), _mode(base_plus_offset), _target(NULL) { }
-  Address(Register r, long o)
-    : _base(r),     _index(noreg), _offset(o), _mode(base_plus_offset), _target(NULL) { }
-  Address(Register r, long long o)
-    : _base(r),     _index(noreg), _offset(o), _mode(base_plus_offset), _target(NULL) { }
-  Address(Register r, unsigned int o)
-    : _base(r),     _index(noreg), _offset(o), _mode(base_plus_offset), _target(NULL) { }
-  Address(Register r, unsigned long o)
-    : _base(r),     _index(noreg), _offset(o), _mode(base_plus_offset), _target(NULL) { }
-  Address(Register r, unsigned long long o)
-    : _base(r),     _index(noreg), _offset(o), _mode(base_plus_offset), _target(NULL) { }
+
+  template<typename T, ENABLE_IF(std::is_integral<T>::value)>
+  Address(Register r, T o)
+    : _base(r), _index(noreg), _offset(o), _mode(base_plus_offset), _target(NULL) {}
+
   Address(Register r, ByteSize disp)
     : Address(r, in_bytes(disp)) {}
   Address(address target, RelocationHolder const& rspec)

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -29,6 +29,7 @@
 
 #include "asm/register.hpp"
 #include "assembler_riscv.inline.hpp"
+#include "metaprogramming/enableIf.hpp"
 
 #define XLEN 64
 

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -201,8 +201,12 @@ void C2_MacroAssembler::string_indexof_char(Register str1, Register cnt1,
     slli(cnt1, cnt1, 1);
   }
 
-  mv(mask1, isL ? 0x0101010101010101 : 0x0001000100010001);
-  mv(mask2, isL ? 0x7f7f7f7f7f7f7f7f : 0x7fff7fff7fff7fff);
+  uint64_t mask0101 = UCONST64(0x0101010101010101);
+  uint64_t mask0001 = UCONST64(0x0001000100010001);
+  mv(mask1, isL ? mask0101 : mask0001);
+  uint64_t mask7f7f = UCONST64(0x7f7f7f7f7f7f7f7f);
+  uint64_t mask7fff = UCONST64(0x7fff7fff7fff7fff);
+  mv(mask2, isL ? mask7f7f : mask7fff);
 
   bind(CH1_LOOP);
   ld(ch1, Address(str1));

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.cpp
@@ -1381,18 +1381,6 @@ void MacroAssembler::reinit_heapbase() {
   }
 }
 
-void MacroAssembler::mv(Register Rd, int64_t imm64) {
-  li(Rd, imm64);
-}
-
-void MacroAssembler::mv(Register Rd, int imm) {
-  mv(Rd, (int64_t)imm);
-}
-
-void MacroAssembler::mvw(Register Rd, int32_t imm32) {
-  mv(Rd, imm32);
-}
-
 void MacroAssembler::mv(Register Rd, Address dest) {
   assert(dest.getMode() == Address::literal, "Address mode should be Address::literal");
   code_section()->relocate(pc(), dest.rspec());

--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -28,6 +28,7 @@
 #define CPU_RISCV_MACROASSEMBLER_RISCV_HPP
 
 #include "asm/assembler.hpp"
+#include "metaprogramming/enableIf.hpp"
 #include "oops/compressedOops.hpp"
 #include "utilities/powerOfTwo.hpp"
 
@@ -518,9 +519,13 @@ class MacroAssembler: public Assembler {
   }
 
   // mv
-  void mv(Register Rd, int64_t imm64);
-  void mv(Register Rd, int imm);
-  void mvw(Register Rd, int32_t imm32);
+  template<typename T, ENABLE_IF(std::is_integral<T>::value)>
+  inline void mv(Register Rd, T o) {
+    li(Rd, (int64_t)o);
+  }
+
+  inline void mvw(Register Rd, int32_t imm32) { mv(Rd, imm32); }
+
   void mv(Register Rd, Address dest);
   void mv(Register Rd, address addr);
   void mv(Register Rd, RegisterOrConstant src);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2562,9 +2562,13 @@ class StubGenerator: public StubCodeGenerator {
 
     // first is needle[0]
     __ andi(first, ch1, needle_isL ? 0xFF : 0xFFFF, first);
-    __ mv(mask1, haystack_isL ? 0x0101010101010101 : 0x0001000100010001);
+    uint64_t mask0101 = UCONST64(0x0101010101010101);
+    uint64_t mask0001 = UCONST64(0x0001000100010001);
+    __ mv(mask1, haystack_isL ? mask0101 : mask0001);
     __ mul(first, first, mask1);
-    __ mv(mask2, haystack_isL ? 0x7f7f7f7f7f7f7f7f : 0x7fff7fff7fff7fff);
+    uint64_t mask7f7f = UCONST64(0x7f7f7f7f7f7f7f7f);
+    uint64_t mask7fff = UCONST64(0x7fff7fff7fff7fff);
+    __ mv(mask2, haystack_isL ? mask7f7f : mask7fff);
     if (needle_isL != haystack_isL) {
       __ mv(tmp, ch1);
     }


### PR DESCRIPTION
The riscv port should follow https://bugs.openjdk.java.net/browse/JDK-8248404, for the same reason of:
```
In many cases the RISCV64 back end uses long and unsigned long types. These types don't work on LLP64 systems (such as Windows) and should be replaced either by int64_t or jlong, as appropriate.
```

Hotspot/jdk tier1 passed on the unmatched board. And all jtreg tests have been tested on Qemu without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280683](https://bugs.openjdk.java.net/browse/JDK-8280683): riscv: Remove uses of long and unsigned long


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/55.diff">https://git.openjdk.java.net/riscv-port/pull/55.diff</a>

</details>
