### PR TITLE
8280845: riscv: Intrinsify BigInteger.montgomerySquare

### DIFF
--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -203,6 +203,10 @@ void VM_Version::c2_initialize() {
   if (FLAG_IS_DEFAULT(UseMontgomeryMultiplyIntrinsic)) {
     FLAG_SET_DEFAULT(UseMontgomeryMultiplyIntrinsic, true);
   }
+
+  if (FLAG_IS_DEFAULT(UseMontgomerySquareIntrinsic)) {
+    FLAG_SET_DEFAULT(UseMontgomerySquareIntrinsic, true);
+  }
 }
 #endif // COMPILER2
 


### PR DESCRIPTION
Intrinsify BigInteger.montgomerySquare on RISCV.
On unmatched borad,  performance of SPECjvm2008 crypto with intrinsic has improved 40%. 
Hotspot/jdk tier1 passed on the unmatched board. And all jtreg tests have been tested on Qemu without new failures.

The details are as follows：
Tested with option “UseMontgomerySquareIntrinsic”.
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:\Users\Z00540~1\AppData\Local\Temp\msohtmlclip1\01\clip.htm">
<link rel=File-List
href="file:///C:\Users\Z00540~1\AppData\Local\Temp\msohtmlclip1\01\clip_filelist.xml">

<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{mso-header-data:"&C&\0022Times New Roman\,Regular\0022&12&A";
	mso-footer-data:"&C&\0022Times New Roman\,Regular\0022&12Page &P";
	margin:1.05in .79in 1.05in .79in;
	mso-header-margin:.79in;
	mso-footer-margin:.79in;
	mso-page-numbers-start:1;}
.font5
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:宋体;
	mso-generic-font-family:auto;
	mso-font-charset:134;}
tr
	{mso-height-source:auto;
	mso-ruby-visibility:none;}
col
	{mso-width-source:auto;
	mso-ruby-visibility:none;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:windowtext;
	font-size:10.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Arial, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:"\0022TRUE\0022\;\0022TRUE\0022\;\0022FALSE\0022";
	text-align:center;}
.xl66
	{mso-number-format:Percent;}
.xl67
	{mso-number-format:"0\.00_ ";}
ruby
	{ruby-align:left;}
rt
	{color:windowtext;
	font-size:9.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:宋体;
	mso-generic-font-family:auto;
	mso-font-charset:134;
	mso-char-type:none;
	display:none;}
-->

</head>

<body link="#0563C1" vlink="#954F72">



TRUE(ops/m) | 1 | 2 | 3 | 4 | geomean |  
-- | -- | -- | -- | -- | -- | --
crypto.aes | 6.04 | 6.07 | 5.78 | 5.76 | 5.91 | 100.81%
crypto.rsa | 171.75 | 172.01 | 172.03 | 172.07 | 171.96 | 239.34%
crypto.signverify | 63.91 | 63.77 | 63.96 | 63.76 | 63.85 | 114.35%
crypto | 40.48 | 40.52 | 39.92 | 39.84 | 40.19 | 140.25%
FALSE(ops/m) |   |   |   |   |   |  
crypto.aes | 5.75 | 5.75 | 6.26 | 5.71 | 5.86 |  
crypto.rsa | 72.86 | 73.22 | 68.87 | 72.53 | 71.85 |  
crypto.signverify | 55.75 | 55.55 | 55.76 | 56.29 | 55.84 |  
crypto | 28.58 | 28.6 | 28.87 | 28.57 | 28.65 |  



</body>

</html>

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8280845](https://bugs.openjdk.java.net/browse/JDK-8280845): riscv: Intrinsify BigInteger.montgomerySquare


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/56.diff">https://git.openjdk.java.net/riscv-port/pull/56.diff</a>

</details>
