### PR TITLE
8281731: riscv: Refactor instruction extraction code in nativeInst_riscv.h/cpp

### DIFF
--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -85,33 +85,32 @@ bool NativeInstruction::is_load_pc_relative_at(address instr) {
 }
 
 bool NativeInstruction::is_movptr_at(address instr) {
-  address pos = instr;
-  return is_lui_at(pos) && // Lui
-         is_addi_at(pos += instruction_size) && // Addi
-         is_slli_shift_at(pos += instruction_size, 11) && // Slli Rd, Rs, 11
-         is_addi_at(pos += instruction_size) && // Addi
-         is_slli_shift_at(pos += instruction_size, 5) && // Slli Rd, Rs, 5
-         (is_addi_at(pos += instruction_size) || is_jalr_at(pos) || is_load_at(pos)) && // Addi/Jalr/Load
+  return is_lui_at(instr) && // Lui
+         is_addi_at(instr + instruction_size) && // Addi
+         is_slli_shift_at(instr + instruction_size * 2, 11) && // Slli Rd, Rs, 11
+         is_addi_at(instr + instruction_size * 3) && // Addi
+         is_slli_shift_at(instr + instruction_size * 4, 5) && // Slli Rd, Rs, 5
+         (is_addi_at(instr + instruction_size * 5) ||
+          is_jalr_at(instr + instruction_size * 5) ||
+          is_load_at(instr + instruction_size * 5)) && // Addi/Jalr/Load
          check_movptr_data_dependency(instr);
 }
 
 bool NativeInstruction::is_li32_at(address instr) {
-  address pos = instr;
-  return is_lui_at(pos) && // lui
-         is_addiw_at(pos += instruction_size) && // addiw
+  return is_lui_at(instr) && // lui
+         is_addiw_at(instr + instruction_size) && // addiw
          check_li32_data_dependency(instr);
 }
 
 bool NativeInstruction::is_li64_at(address instr) {
-  address pos = instr;
-  return is_lui_at(pos) && // lui
-         is_addi_at(pos += instruction_size) && // addi
-         is_slli_shift_at(pos += instruction_size, 12) &&  // Slli Rd, Rs, 12
-         is_addi_at(pos += instruction_size) && // addi
-         is_slli_shift_at(pos += instruction_size, 12) &&  // Slli Rd, Rs, 12
-         is_addi_at(pos += instruction_size) && // addi
-         is_slli_shift_at(pos += instruction_size, 8) &&   // Slli Rd, Rs, 8
-         is_addi_at(pos += instruction_size) && // addi
+  return is_lui_at(instr) && // lui
+         is_addi_at(instr + instruction_size) && // addi
+         is_slli_shift_at(instr + instruction_size * 2, 12) &&  // Slli Rd, Rs, 12
+         is_addi_at(instr + instruction_size * 3) && // addi
+         is_slli_shift_at(instr + instruction_size * 4, 12) &&  // Slli Rd, Rs, 12
+         is_addi_at(instr + instruction_size * 5) && // addi
+         is_slli_shift_at(instr + instruction_size * 6, 8) &&   // Slli Rd, Rs, 8
+         is_addi_at(instr + instruction_size * 7) && // addi
          check_li64_data_dependency(instr);
 }
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -380,8 +380,6 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
 }
 
 void NativeGeneralJump::insert_unconditional(address code_pos, address entry) {
-  NativeGeneralJump* n_jump = (NativeGeneralJump*)code_pos;
-
   CodeBuffer cb(code_pos, instruction_size);
   MacroAssembler a(&cb);
 

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -39,64 +39,80 @@
 #include "c1/c1_Runtime1.hpp"
 #endif
 
+Register NativeInstruction::extract_rs1(address instr) {
+  assert_cond(instr != NULL);
+  return as_Register(Assembler::extract(((unsigned*)instr)[0], 19, 15));
+}
+
+Register NativeInstruction::extract_rs2(address instr) {
+  assert_cond(instr != NULL);
+  return as_Register(Assembler::extract(((unsigned*)instr)[0], 24, 20));
+}
+
+Register NativeInstruction::extract_rd(address instr) {
+  assert_cond(instr != NULL);
+  return as_Register(Assembler::extract(((unsigned*)instr)[0], 11, 7));
+}
+
+uint32_t NativeInstruction::extract_opcode(address instr) {
+  assert_cond(instr != NULL);
+  return Assembler::extract(((unsigned*)instr)[0], 6, 0);
+}
+
+uint32_t NativeInstruction::extract_funct3(address instr) {
+  assert_cond(instr != NULL);
+  return Assembler::extract(((unsigned*)instr)[0], 14, 12);
+}
+
 bool NativeInstruction::is_pc_relative_at(address instr) {
   // auipc + jalr
   // auipc + addi
   // auipc + load
   // auipc + fload_load
-  if ((is_auipc_at(instr)) &&
-      (is_addi_at(instr + 4) || is_jalr_at(instr + 4) || is_load_at(instr + 4) || is_float_load_at(instr + 4)) &&
-      check_pc_relative_data_dependency(instr)) {
-    return true;
-  }
-  return false;
+  return (is_auipc_at(instr)) &&
+         (is_addi_at(instr + instruction_size) ||
+          is_jalr_at(instr + instruction_size) ||
+          is_load_at(instr + instruction_size) ||
+          is_float_load_at(instr + instruction_size)) &&
+         check_pc_relative_data_dependency(instr);
 }
 
 // ie:ld(Rd, Label)
 bool NativeInstruction::is_load_pc_relative_at(address instr) {
-  if (is_auipc_at(instr) && // auipc
-      is_ld_at(instr + 4) && // ld
-      check_load_pc_relative_data_dependency(instr)) {
-      return true;
-  }
-  return false;
+  return is_auipc_at(instr) && // auipc
+         is_ld_at(instr + instruction_size) && // ld
+         check_load_pc_relative_data_dependency(instr);
 }
 
 bool NativeInstruction::is_movptr_at(address instr) {
-  if (is_lui_at(instr) && // Lui
-      is_addi_at(instr + 4) && // Addi
-      is_slli_shift_at(instr + 8, 11) && // Slli Rd, Rs, 11
-      is_addi_at(instr + 12) && // Addi
-      is_slli_shift_at(instr + 16, 5) && // Slli Rd, Rs, 5
-      (is_addi_at(instr + 20) || is_jalr_at(instr + 20) || is_load_at(instr + 20)) && // Addi/Jalr/Load
-      check_movptr_data_dependency(instr)) {
-    return true;
-  }
-  return false;
+  address pos = instr;
+  return is_lui_at(pos) && // Lui
+         is_addi_at(pos += instruction_size) && // Addi
+         is_slli_shift_at(pos += instruction_size, 11) && // Slli Rd, Rs, 11
+         is_addi_at(pos += instruction_size) && // Addi
+         is_slli_shift_at(pos += instruction_size, 5) && // Slli Rd, Rs, 5
+         (is_addi_at(pos += instruction_size) || is_jalr_at(pos) || is_load_at(pos)) && // Addi/Jalr/Load
+         check_movptr_data_dependency(instr);
 }
 
 bool NativeInstruction::is_li32_at(address instr) {
-  if (is_lui_at(instr) && // lui
-      is_addiw_at(instr + 4) && // addiw
-      check_li32_data_dependency(instr)) {
-    return true;
-  }
-  return false;
+  address pos = instr;
+  return is_lui_at(pos) && // lui
+         is_addiw_at(pos += instruction_size) && // addiw
+         check_li32_data_dependency(instr);
 }
 
 bool NativeInstruction::is_li64_at(address instr) {
-  if (is_lui_at(instr) && // lui
-      is_addi_at(instr + 4) && // addi
-      is_slli_shift_at(instr + 8, 12)&&  // Slli Rd, Rs, 12
-      is_addi_at(instr + 12) && // addi
-      is_slli_shift_at(instr + 16, 12) && // Slli Rd, Rs, 12
-      is_addi_at(instr + 20) && // addi
-      is_slli_shift_at(instr + 24, 8) && // Slli Rd, Rs, 8
-      is_addi_at(instr + 28) && // addi
-      check_li64_data_dependency(instr)) {
-    return true;
-  }
-  return false;
+  address pos = instr;
+  return is_lui_at(pos) && // lui
+         is_addi_at(pos += instruction_size) && // addi
+         is_slli_shift_at(pos += instruction_size, 12) &&  // Slli Rd, Rs, 12
+         is_addi_at(pos += instruction_size) && // addi
+         is_slli_shift_at(pos += instruction_size, 12) &&  // Slli Rd, Rs, 12
+         is_addi_at(pos += instruction_size) && // addi
+         is_slli_shift_at(pos += instruction_size, 8) &&   // Slli Rd, Rs, 8
+         is_addi_at(pos += instruction_size) && // addi
+         check_li64_data_dependency(instr);
 }
 
 void NativeCall::verify() {
@@ -307,10 +323,9 @@ bool NativeInstruction::is_safepoint_poll() {
 
 bool NativeInstruction::is_lwu_to_zr(address instr) {
   assert_cond(instr != NULL);
-  unsigned insn = *(unsigned*)instr;
-  return (Assembler::extract(insn, 6, 0) == 0b0000011 &&
-          Assembler::extract(insn, 14, 12) == 0b110 &&
-          Assembler::extract(insn, 11, 7) == 0b00000); // zr
+  return (extract_opcode(instr) == 0b0000011 &&
+          extract_funct3(instr) == 0b110 &&
+          extract_rd(instr) == zr);         // zr
 }
 
 // A 16-bit instruction with all bits ones is permanently reserved as an illegal instruction.

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -98,21 +98,31 @@ class NativeInstruction {
   //     slli
   //     addi/jalr/load
   static bool check_movptr_data_dependency(address instr) {
-    address lui = instr;
-    address addi1 = lui + instruction_size;
-    address slli1 = addi1 + instruction_size;
-    address addi2 = slli1 + instruction_size;
-    address slli2 = addi2 + instruction_size;
-    address last_instr = slli2 + instruction_size;
-    return extract_rs1(addi1) == extract_rd(lui) &&
-           extract_rs1(addi1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(slli2) &&
-           extract_rs1(last_instr) == extract_rd(slli2);
+    const address lui = instr;
+    const Register lui_rd = extract_rd(lui);
+    const address addi1 = lui + instruction_size;
+    const Register addi1_rs1 = extract_rs1(addi1);
+    const Register addi1_rd  = extract_rd(addi1);
+    const address slli1 = addi1 + instruction_size;
+    const Register slli1_rs1 = extract_rs1(slli1);
+    const Register slli1_rd  = extract_rd(slli1);
+    const address addi2 = slli1 + instruction_size;
+    const Register addi2_rs1 = extract_rs1(addi2);
+    const Register addi2_rd  = extract_rd(addi2);
+    const address slli2 = addi2 + instruction_size;
+    const Register slli2_rs1 = extract_rs1(slli2);
+    const Register slli2_rd  = extract_rd(slli2);
+    const address last_instr = slli2 + instruction_size;
+    const Register last_instr_rs1 = extract_rs1(last_instr);
+    return addi1_rs1 == lui_rd &&
+           addi1_rs1 == addi1_rd &&
+           slli1_rs1 == addi1_rd &&
+           slli1_rs1 == slli1_rd &&
+           addi2_rs1 == slli1_rd &&
+           addi2_rs1 == addi2_rd &&
+           slli2_rs1 == addi2_rd &&
+           slli2_rs1 == slli2_rd &&
+           last_instr_rs1 == slli2_rd;
   }
 
   // the instruction sequence of li64 is as below:
@@ -125,47 +135,65 @@ class NativeInstruction {
   //     slli
   //     addi
   static bool check_li64_data_dependency(address instr) {
-    address lui = instr;
-    address addi1 = lui + instruction_size;
-    address slli1 = addi1 + instruction_size;
-    address addi2 = slli1 + instruction_size;
-    address slli2 = addi2 + instruction_size;
-    address addi3 = slli2 + instruction_size;
-    address slli3 = addi3 + instruction_size;
-    address addi4 = slli3 + instruction_size;
-    return extract_rs1(addi1) == extract_rd(lui) &&
-           extract_rs1(addi1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(addi1) &&
-           extract_rs1(slli1) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(slli1) &&
-           extract_rs1(addi2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(addi2) &&
-           extract_rs1(slli2) == extract_rd(slli2) &&
-           extract_rs1(addi3) == extract_rd(slli2) &&
-           extract_rs1(addi3) == extract_rd(addi3) &&
-           extract_rs1(slli3) == extract_rd(addi3) &&
-           extract_rs1(slli3) == extract_rd(slli3) &&
-           extract_rs1(addi4) == extract_rd(slli3) &&
-           extract_rs1(addi4) == extract_rd(addi4);
+    const address lui = instr;
+    const Register lui_rd = extract_rd(lui);
+    const address addi1 = lui + instruction_size;
+    const Register addi1_rs1 = extract_rs1(addi1);
+    const Register addi1_rd  = extract_rd(addi1);
+    const address slli1 = addi1 + instruction_size;
+    const Register slli1_rs1 = extract_rs1(slli1);
+    const Register slli1_rd  = extract_rd(slli1);
+    const address addi2 = slli1 + instruction_size;
+    const Register addi2_rs1 = extract_rs1(addi2);
+    const Register addi2_rd  = extract_rd(addi2);
+    const address slli2 = addi2 + instruction_size;
+    const Register slli2_rs1 = extract_rs1(slli2);
+    const Register slli2_rd  = extract_rd(slli2);
+    const address addi3 = slli2 + instruction_size;
+    const Register addi3_rs1 = extract_rs1(addi3);
+    const Register addi3_rd  = extract_rd(addi3);
+    const address slli3 = addi3 + instruction_size;
+    const Register slli3_rs1 = extract_rs1(slli3);
+    const Register slli3_rd  = extract_rd(slli3);
+    const address addi4 = slli3 + instruction_size;
+    const Register addi4_rs1 = extract_rs1(addi4);
+    const Register addi4_rd  = extract_rd(addi4);
+    return addi1_rs1 == lui_rd &&
+           addi1_rs1 == addi1_rd &&
+           slli1_rs1 == addi1_rd &&
+           slli1_rs1 == slli1_rd &&
+           addi2_rs1 == slli1_rd &&
+           addi2_rs1 == addi2_rd &&
+           slli2_rs1 == addi2_rd &&
+           slli2_rs1 == slli2_rd &&
+           addi3_rs1 == slli2_rd &&
+           addi3_rs1 == addi3_rd &&
+           slli3_rs1 == addi3_rd &&
+           slli3_rs1 == slli3_rd &&
+           addi4_rs1 == slli3_rd &&
+           addi4_rs1 == addi4_rd;
   }
 
   // the instruction sequence of li32 is as below:
   //     lui
   //     addiw
   static bool check_li32_data_dependency(address instr) {
-    address lui = instr;
-    address addiw = lui + instruction_size;
+    const address lui = instr;
+    const Register lui_rd = extract_rd(lui);
+    const address addiw = lui + instruction_size;
+    const Register addiw_rs1 = extract_rs1(addiw);
+    const Register addiw_rd  = extract_rd(addiw);
 
-    return extract_rs1(addiw) == extract_rd(lui) &&
-           extract_rs1(addiw) == extract_rd(addiw);
+    return addiw_rs1 == lui_rd &&
+           addiw_rs1 == addiw_rd;
   }
 
   // the instruction sequence of pc-relative is as below:
   //     auipc
   //     jalr/addi/load/float_load
   static bool check_pc_relative_data_dependency(address instr) {
-    address auipc = instr;
-    address last_instr = auipc + instruction_size;
+    const address auipc = instr;
+    const address last_instr = auipc + instruction_size;
 
     return extract_rs1(last_instr) == extract_rd(auipc);
   }
@@ -174,11 +202,14 @@ class NativeInstruction {
   //     auipc
   //     load
   static bool check_load_pc_relative_data_dependency(address instr) {
-    address auipc = instr;
-    address load = auipc + instruction_size;
+    const address auipc = instr;
+    const Register auipc_rd = extract_rd(auipc);
+    const address load = auipc + instruction_size;
+    const Register load_rs1 = extract_rs1(load);
+    const Register load_rd  = extract_rd(load);
 
-    return extract_rd(load) == extract_rd(auipc) &&
-           extract_rs1(load) == extract_rd(load);
+    return load_rd == auipc_rd &&
+           load_rs1 == load_rd;
   }
 
   static bool is_movptr_at(address instr);

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -66,33 +66,29 @@ class NativeInstruction {
   bool is_call()                            const { return is_call_at(addr_at(0));        }
   bool is_jump()                            const { return is_jump_at(addr_at(0));        }
 
-  static bool is_jal_at(address instr)        { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b1101111; }
-  static bool is_jalr_at(address instr)       { assert_cond(instr != NULL); return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b1100111 &&
-                                                Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b000); }
-  static bool is_branch_at(address instr)     { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b1100011; }
-  static bool is_ld_at(address instr)         { assert_cond(instr != NULL); return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0000011 &&
-                                                Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b011); }
-  static bool is_load_at(address instr)       { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0000011; }
-  static bool is_float_load_at(address instr) { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0000111; }
-  static bool is_auipc_at(address instr)      { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0010111; }
-  static bool is_jump_at(address instr)       { assert_cond(instr != NULL); return (is_branch_at(instr) || is_jal_at(instr) || is_jalr_at(instr)); }
-  static bool is_addi_at(address instr)       { assert_cond(instr != NULL); return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0010011 &&
-                                                Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b000); }
-  static bool is_addiw_at(address instr)      { assert_cond(instr != NULL); return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0011011 &&
-                                                Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b000); }
-  static bool is_lui_at(address instr)        { assert_cond(instr != NULL); return Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0110111; }
+  static bool is_jal_at(address instr)        { assert_cond(instr != NULL); return extract_opcode(instr) == 0b1101111; }
+  static bool is_jalr_at(address instr)       { assert_cond(instr != NULL); return extract_opcode(instr) == 0b1100111 && extract_funct3(instr) == 0b000; }
+  static bool is_branch_at(address instr)     { assert_cond(instr != NULL); return extract_opcode(instr) == 0b1100011; }
+  static bool is_ld_at(address instr)         { assert_cond(instr != NULL); return is_load_at(instr) && extract_funct3(instr) == 0b011; }
+  static bool is_load_at(address instr)       { assert_cond(instr != NULL); return extract_opcode(instr) == 0b0000011; }
+  static bool is_float_load_at(address instr) { assert_cond(instr != NULL); return extract_opcode(instr) == 0b0000111; }
+  static bool is_auipc_at(address instr)      { assert_cond(instr != NULL); return extract_opcode(instr) == 0b0010111; }
+  static bool is_jump_at(address instr)       { assert_cond(instr != NULL); return is_branch_at(instr) || is_jal_at(instr) || is_jalr_at(instr); }
+  static bool is_addi_at(address instr)       { assert_cond(instr != NULL); return extract_opcode(instr) == 0b0010011 && extract_funct3(instr) == 0b000; }
+  static bool is_addiw_at(address instr)      { assert_cond(instr != NULL); return extract_opcode(instr) == 0b0011011 && extract_funct3(instr) == 0b000; }
+  static bool is_lui_at(address instr)        { assert_cond(instr != NULL); return extract_opcode(instr) == 0b0110111; }
   static bool is_slli_shift_at(address instr, uint32_t shift) {
     assert_cond(instr != NULL);
-    return (Assembler::extract(((unsigned*)instr)[0], 6, 0) == 0b0010011 && // opcode field
-            Assembler::extract(((unsigned*)instr)[0], 14, 12) == 0b001 &&   // funct3 field, select the type of operation
+    return (extract_opcode(instr) == 0b0010011 && // opcode field
+            extract_funct3(instr) == 0b001 &&     // funct3 field, select the type of operation
             Assembler::extract(((unsigned*)instr)[0], 25, 20) == shift);    // shamt field
   }
 
-  // return true if the (index1~index2) field of instr1 is equal to (index3~index4) field of instr2, otherwise false
-  static bool compare_instr_field(address instr1, int index1, int index2, address instr2, int index3, int index4) {
-    assert_cond(instr1 != NULL && instr2 != NULL);
-    return Assembler::extract(((unsigned*)instr1)[0], index1, index2) == Assembler::extract(((unsigned*)instr2)[0], index3, index4);
-  }
+  static Register extract_rs1(address instr);
+  static Register extract_rs2(address instr);
+  static Register extract_rd(address instr);
+  static uint32_t extract_opcode(address instr);
+  static uint32_t extract_funct3(address instr);
 
   // the instruction sequence of movptr is as below:
   //     lui
@@ -102,15 +98,21 @@ class NativeInstruction {
   //     slli
   //     addi/jalr/load
   static bool check_movptr_data_dependency(address instr) {
-    return compare_instr_field(instr + 4, 19, 15, instr, 11, 7)       &&     // check the rs1 field of addi and the rd field of lui
-           compare_instr_field(instr + 4, 19, 15, instr + 4, 11, 7)   &&     // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 8, 19, 15, instr + 4, 11, 7)   &&     // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 8, 19, 15, instr + 8, 11, 7)   &&     // check the rs1 field and the rd field of slli
-           compare_instr_field(instr + 12, 19, 15, instr + 8, 11, 7)  &&     // check the rs1 field of addi and the rd field of slli
-           compare_instr_field(instr + 12, 19, 15, instr + 12, 11, 7) &&     // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 16, 19, 15, instr + 12, 11, 7) &&     // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 16, 19, 15, instr + 16, 11, 7) &&     // check the rs1 field and the rd field of slli
-           compare_instr_field(instr + 20, 19, 15, instr + 16, 11, 7);       // check the rs1 field of addi/jalr/load and the rd field of slli
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instruction_size;
+    address slli2 = addi2 + instruction_size;
+    address last_instr = slli2 + instruction_size;
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(last_instr) == extract_rd(slli2);
   }
 
   // the instruction sequence of li64 is as below:
@@ -123,43 +125,60 @@ class NativeInstruction {
   //     slli
   //     addi
   static bool check_li64_data_dependency(address instr) {
-    return compare_instr_field(instr + 4, 19, 15, instr, 11, 7)       &&  // check the rs1 field of addi and the rd field of lui
-           compare_instr_field(instr + 4, 19, 15, instr + 4, 11, 7)   &&  // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 8, 19, 15, instr + 4, 11, 7)   &&  // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 8, 19, 15, instr + 8, 11, 7)   &&  // check the rs1 field and the rd field of slli
-           compare_instr_field(instr + 12, 19, 15, instr + 8, 11, 7)  &&  // check the rs1 field of addi and the rd field of slli
-           compare_instr_field(instr + 12, 19, 15, instr + 12, 11, 7) &&  // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 16, 19, 15, instr + 12, 11, 7) &&  // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 16, 19, 15, instr + 16, 11, 7) &&  // check the rs1 field and the rd field fof slli
-           compare_instr_field(instr + 20, 19, 15, instr + 16, 11, 7) &&  // check the rs1 field of addi and the rd field of slli
-           compare_instr_field(instr + 20, 19, 15, instr + 20, 11, 7) &&  // check the rs1 field and the rd field of addi
-           compare_instr_field(instr + 24, 19, 15, instr + 20, 11, 7) &&  // check the rs1 field of slli and the rd field of addi
-           compare_instr_field(instr + 24, 19, 15, instr + 24, 11, 7) &&  // check the rs1 field and the rd field of slli
-           compare_instr_field(instr + 28, 19, 15, instr + 24, 11, 7) &&  // check the rs1 field of addi and the rd field of slli
-           compare_instr_field(instr + 28, 19, 15, instr + 28, 11, 7);    // check the rs1 field and the rd field of addi
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instruction_size;
+    address slli2 = addi2 + instruction_size;
+    address addi3 = slli2 + instruction_size;
+    address slli3 = addi3 + instruction_size;
+    address addi4 = slli3 + instruction_size;
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(addi4);
   }
 
   // the instruction sequence of li32 is as below:
   //     lui
   //     addiw
   static bool check_li32_data_dependency(address instr) {
-    return compare_instr_field(instr + 4, 19, 15, instr, 11, 7) &&     // check the rs1 field of addiw and the rd field of lui
-           compare_instr_field(instr + 4, 19, 15, instr + 4, 11, 7);   // check the rs1 field and the rd field of addiw
+    address lui = instr;
+    address addiw = lui + instruction_size;
+
+    return extract_rs1(addiw) == extract_rd(lui) &&
+           extract_rs1(addiw) == extract_rd(addiw);
   }
 
   // the instruction sequence of pc-relative is as below:
   //     auipc
   //     jalr/addi/load/float_load
   static bool check_pc_relative_data_dependency(address instr) {
-    return compare_instr_field(instr, 11, 7, instr + 4, 19, 15);          // check the rd field of auipc and the rs1 field of jalr/addi/load/float_load
+    address auipc = instr;
+    address last_instr = auipc + instruction_size;
+
+    return extract_rs1(last_instr) == extract_rd(auipc);
   }
 
   // the instruction sequence of load_label is as below:
   //     auipc
   //     load
   static bool check_load_pc_relative_data_dependency(address instr) {
-    return compare_instr_field(instr, 11, 7, instr + 4, 11, 7) &&      // check the rd field of auipc and the rd field of load
-           compare_instr_field(instr + 4, 19, 15, instr + 4, 11, 7);   // check the rs1 field of load and the rd field of load
+    address auipc = instr;
+    address load = auipc + instruction_size;
+
+    return extract_rd(load) == extract_rd(auipc) &&
+           extract_rs1(load) == extract_rd(load);
   }
 
   static bool is_movptr_at(address instr);
@@ -210,8 +229,7 @@ class NativeInstruction {
   }
 
   bool is_membar() {
-    unsigned int insn = uint_at(0);
-    return (insn & 0x7f) == 0b1111 && Assembler::extract(insn, 14, 12) == 0;
+    return (uint_at(0) & 0x7f) == 0b1111 && extract_funct3(addr_at(0)) == 0;
   }
 };
 
@@ -517,11 +535,12 @@ inline bool is_NativeCallTrampolineStub_at(address addr) {
   // 2). check if auipc[11:7] == t0 and ld[11:7] == t0 and ld[19:15] == t0 && jr[19:15] == t0
   // 3). check if the offset in ld[31:20] equals the data_offset
   assert_cond(addr != NULL);
-  if (NativeInstruction::is_auipc_at(addr) && NativeInstruction::is_ld_at(addr + 4) && NativeInstruction::is_jalr_at(addr + 8) &&
-      (as_Register((intptr_t)Assembler::extract(((unsigned*)addr)[0], 11, 7))     == x5) &&
-      (as_Register((intptr_t)Assembler::extract(((unsigned*)addr)[1], 11, 7))     == x5) &&
-      (as_Register((intptr_t)Assembler::extract(((unsigned*)addr)[1], 19, 15))    == x5) &&
-      (as_Register((intptr_t)Assembler::extract(((unsigned*)addr)[2], 19, 15))    == x5) &&
+  const int instr_size = NativeInstruction::instruction_size;
+  if (NativeInstruction::is_auipc_at(addr) && NativeInstruction::is_ld_at(addr + instr_size) && NativeInstruction::is_jalr_at(addr + 2 * instr_size) &&
+      (NativeInstruction::extract_rd(addr)                    == x5) &&
+      (NativeInstruction::extract_rd(addr + instr_size)       == x5) &&
+      (NativeInstruction::extract_rs1(addr + instr_size)      == x5) &&
+      (NativeInstruction::extract_rs1(addr + 2 * instr_size)  == x5) &&
       (Assembler::extract(((unsigned*)addr)[1], 31, 20) == NativeCallTrampolineStub::data_offset)) {
     return true;
   }

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -196,10 +196,7 @@ class NativeInstruction {
   static bool is_lwu_to_zr(address instr);
 
   inline bool is_nop();
-  inline bool is_illegal();
-  inline bool is_return();
   inline bool is_jump_or_nop();
-  inline bool is_cond_jump();
   bool is_safepoint_poll();
   bool is_sigill_zombie_not_entrant();
   bool is_stop();

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -98,31 +98,21 @@ class NativeInstruction {
   //     slli
   //     addi/jalr/load
   static bool check_movptr_data_dependency(address instr) {
-    const address lui = instr;
-    const Register lui_rd = extract_rd(lui);
-    const address addi1 = lui + instruction_size;
-    const Register addi1_rs1 = extract_rs1(addi1);
-    const Register addi1_rd  = extract_rd(addi1);
-    const address slli1 = addi1 + instruction_size;
-    const Register slli1_rs1 = extract_rs1(slli1);
-    const Register slli1_rd  = extract_rd(slli1);
-    const address addi2 = slli1 + instruction_size;
-    const Register addi2_rs1 = extract_rs1(addi2);
-    const Register addi2_rd  = extract_rd(addi2);
-    const address slli2 = addi2 + instruction_size;
-    const Register slli2_rs1 = extract_rs1(slli2);
-    const Register slli2_rd  = extract_rd(slli2);
-    const address last_instr = slli2 + instruction_size;
-    const Register last_instr_rs1 = extract_rs1(last_instr);
-    return addi1_rs1 == lui_rd &&
-           addi1_rs1 == addi1_rd &&
-           slli1_rs1 == addi1_rd &&
-           slli1_rs1 == slli1_rd &&
-           addi2_rs1 == slli1_rd &&
-           addi2_rs1 == addi2_rd &&
-           slli2_rs1 == addi2_rd &&
-           slli2_rs1 == slli2_rd &&
-           last_instr_rs1 == slli2_rd;
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instruction_size;
+    address slli2 = addi2 + instruction_size;
+    address last_instr = slli2 + instruction_size;
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(last_instr) == extract_rd(slli2);
   }
 
   // the instruction sequence of li64 is as below:
@@ -135,65 +125,47 @@ class NativeInstruction {
   //     slli
   //     addi
   static bool check_li64_data_dependency(address instr) {
-    const address lui = instr;
-    const Register lui_rd = extract_rd(lui);
-    const address addi1 = lui + instruction_size;
-    const Register addi1_rs1 = extract_rs1(addi1);
-    const Register addi1_rd  = extract_rd(addi1);
-    const address slli1 = addi1 + instruction_size;
-    const Register slli1_rs1 = extract_rs1(slli1);
-    const Register slli1_rd  = extract_rd(slli1);
-    const address addi2 = slli1 + instruction_size;
-    const Register addi2_rs1 = extract_rs1(addi2);
-    const Register addi2_rd  = extract_rd(addi2);
-    const address slli2 = addi2 + instruction_size;
-    const Register slli2_rs1 = extract_rs1(slli2);
-    const Register slli2_rd  = extract_rd(slli2);
-    const address addi3 = slli2 + instruction_size;
-    const Register addi3_rs1 = extract_rs1(addi3);
-    const Register addi3_rd  = extract_rd(addi3);
-    const address slli3 = addi3 + instruction_size;
-    const Register slli3_rs1 = extract_rs1(slli3);
-    const Register slli3_rd  = extract_rd(slli3);
-    const address addi4 = slli3 + instruction_size;
-    const Register addi4_rs1 = extract_rs1(addi4);
-    const Register addi4_rd  = extract_rd(addi4);
-    return addi1_rs1 == lui_rd &&
-           addi1_rs1 == addi1_rd &&
-           slli1_rs1 == addi1_rd &&
-           slli1_rs1 == slli1_rd &&
-           addi2_rs1 == slli1_rd &&
-           addi2_rs1 == addi2_rd &&
-           slli2_rs1 == addi2_rd &&
-           slli2_rs1 == slli2_rd &&
-           addi3_rs1 == slli2_rd &&
-           addi3_rs1 == addi3_rd &&
-           slli3_rs1 == addi3_rd &&
-           slli3_rs1 == slli3_rd &&
-           addi4_rs1 == slli3_rd &&
-           addi4_rs1 == addi4_rd;
+    address lui = instr;
+    address addi1 = lui + instruction_size;
+    address slli1 = addi1 + instruction_size;
+    address addi2 = slli1 + instruction_size;
+    address slli2 = addi2 + instruction_size;
+    address addi3 = slli2 + instruction_size;
+    address slli3 = addi3 + instruction_size;
+    address addi4 = slli3 + instruction_size;
+    return extract_rs1(addi1) == extract_rd(lui) &&
+           extract_rs1(addi1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(addi1) &&
+           extract_rs1(slli1) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(slli1) &&
+           extract_rs1(addi2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(addi2) &&
+           extract_rs1(slli2) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(slli2) &&
+           extract_rs1(addi3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(addi3) &&
+           extract_rs1(slli3) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(slli3) &&
+           extract_rs1(addi4) == extract_rd(addi4);
   }
 
   // the instruction sequence of li32 is as below:
   //     lui
   //     addiw
   static bool check_li32_data_dependency(address instr) {
-    const address lui = instr;
-    const Register lui_rd = extract_rd(lui);
-    const address addiw = lui + instruction_size;
-    const Register addiw_rs1 = extract_rs1(addiw);
-    const Register addiw_rd  = extract_rd(addiw);
+    address lui = instr;
+    address addiw = lui + instruction_size;
 
-    return addiw_rs1 == lui_rd &&
-           addiw_rs1 == addiw_rd;
+    return extract_rs1(addiw) == extract_rd(lui) &&
+           extract_rs1(addiw) == extract_rd(addiw);
   }
 
   // the instruction sequence of pc-relative is as below:
   //     auipc
   //     jalr/addi/load/float_load
   static bool check_pc_relative_data_dependency(address instr) {
-    const address auipc = instr;
-    const address last_instr = auipc + instruction_size;
+    address auipc = instr;
+    address last_instr = auipc + instruction_size;
 
     return extract_rs1(last_instr) == extract_rd(auipc);
   }
@@ -202,14 +174,11 @@ class NativeInstruction {
   //     auipc
   //     load
   static bool check_load_pc_relative_data_dependency(address instr) {
-    const address auipc = instr;
-    const Register auipc_rd = extract_rd(auipc);
-    const address load = auipc + instruction_size;
-    const Register load_rs1 = extract_rs1(load);
-    const Register load_rd  = extract_rd(load);
+    address auipc = instr;
+    address load = auipc + instruction_size;
 
-    return load_rd == auipc_rd &&
-           load_rs1 == load_rd;
+    return extract_rd(load) == extract_rd(auipc) &&
+           extract_rs1(load) == extract_rd(load);
   }
 
   static bool is_movptr_at(address instr);


### PR DESCRIPTION
Hi team,

Could I have a review of this patch - this is just a trivial refactoring with some cleanups for `nativeInst_riscv.h/cpp` using `Assembler::extract()` with raw bits, by adding `extract_rs1`, `extract_rs2`, `extract_rd`, `extract_opcode`, and `extract_funct3` to make the code cleaner and conciser. Tested hotspot tier1 on Qemu with no other errors found.

Thanks,
Xiaolin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281731](https://bugs.openjdk.java.net/browse/JDK-8281731): riscv: Refactor instruction extraction code in nativeInst_riscv.h/cpp


### Reviewers
 * [Yadong Wang](https://openjdk.java.net/census#yadongwang) (@yadongw - Committer)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/57.diff">https://git.openjdk.java.net/riscv-port/pull/57.diff</a>

</details>
