### PR TITLE
8281632: riscv: Improve interpreter stack banging

### DIFF
--- a/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/macroAssembler_riscv.hpp
@@ -613,8 +613,8 @@ class MacroAssembler: public Assembler {
   void bang_stack_with_offset(int offset) {
     // stack grows down, caller passes positive offset
     assert(offset > 0, "must bang with negative offset");
-    sub(t1, sp, offset);
-    sd(zr, Address(t1));
+    sub(t0, sp, offset);
+    sd(zr, Address(t0));
   }
 
   void la_patchable(Register reg1, const Address &dest, int32_t &offset);

--- a/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/templateInterpreterGenerator_riscv.cpp
@@ -920,7 +920,7 @@ void TemplateInterpreterGenerator::bang_stack_shadow_pages(bool native_call) {
   __ ld(t0, Address(xthread, JavaThread::shadow_zone_growth_watermark()));
   __ bgtu(sp, t0, L_done);
 
-  for (int p = 1; p <= n_shadow_pages ; p++) {
+  for (int p = 1; p <= n_shadow_pages; p++) {
     __ bang_stack_with_offset(p * page_size);
   }
 


### PR DESCRIPTION
With reference to https://bugs.openjdk.java.net/browse/JDK-8072070, there is the same issue on the riscv platform.
 
```
Every time we enter a method in interpreter, we bang a lot of stack ahead for shadow zone checks. I believe this could be made significantly better, e.g. by checking how far away we are from the stack_overflow_limit.
```

Hotspot/jdk tier1 passed on unmatched, and all jtreg cases were tested on Qemu without new failures.

Performed the performance regression test in SPECjvm2008 sunflow, and achieved 17% improvement in the interpreter-only mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281632](https://bugs.openjdk.java.net/browse/JDK-8281632): riscv: Improve interpreter stack banging


### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - **Reviewer**) ⚠️ Review applies to ea9ad368444916afb8c177ba5b29a7e49ac497d5
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/58.diff">https://git.openjdk.java.net/riscv-port/pull/58.diff</a>

</details>
