### PR TITLE
8282331: riscv: is_wide_vector should not depend on specific vector size

### DIFF
--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -216,7 +216,6 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm) {
 }
 
 // Is vector's size (in bytes) bigger than a size saved by default?
-// on riscv, vector registers are awlays saved when RVV is enabled.
 bool SharedRuntime::is_wide_vector(int size) {
   return UseRVV;
 }

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -216,9 +216,9 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm) {
 }
 
 // Is vector's size (in bytes) bigger than a size saved by default?
-// 8 bytes vector registers are saved by default on riscv64.
+// on riscv, vector registers are awlays saved when RVV is enabled.
 bool SharedRuntime::is_wide_vector(int size) {
-  return size > 8;
+  return UseRVV;
 }
 
 // The java_calling_convention describes stack locations as ideal slots on

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -216,8 +216,7 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm) {
 }
 
 // Is vector's size (in bytes) bigger than a size saved by default?
-// riscv do not ovlerlay the floating-point registers on vector registers.
-// vector registers are saved by default on riscv when RVV is enabled.
+// riscv does not ovlerlay the floating-point registers on vector registers like aarch64.
 bool SharedRuntime::is_wide_vector(int size) {
   return UseRVV;
 }

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -216,6 +216,8 @@ void RegisterSaver::restore_live_registers(MacroAssembler* masm) {
 }
 
 // Is vector's size (in bytes) bigger than a size saved by default?
+// riscv do not ovlerlay the floating-point registers on vector registers.
+// vector registers are saved by default on riscv when RVV is enabled.
 bool SharedRuntime::is_wide_vector(int size) {
   return UseRVV;
 }


### PR DESCRIPTION
RISC-V Vector Extension adds 32 architectural vector registers to the base scalar RISC-V ISA, and does not overlay the f registers on v registers. `is_wide_vector` should always return true when RVV is enabled. 
On AArch64, the thirty two registers in the FP/SIMD register bank named V0 to V31 are used to hold floating point  operands for the scalar floating point instructions, and both scalar and vector operands for the Advanced SIMD instructions. 8 bytes vectors registers are saved by default on AArch64.

Tier1 tests on QEMU with UseRVV enabled are passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282331](https://bugs.openjdk.java.net/browse/JDK-8282331): riscv: is_wide_vector should not depend on specific vector size


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/59/head:pull/59` \
`$ git checkout pull/59`

Update a local copy of the PR: \
`$ git checkout pull/59` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/59/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 59`

View PR using the GUI difftool: \
`$ git pr show -t 59`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/59.diff">https://git.openjdk.java.net/riscv-port/pull/59.diff</a>

</details>
