### PR TITLE
8281967: riscv: Intrinsify bigIntegerLeftShift

### DIFF
--- a/src/hotspot/cpu/riscv/globals_riscv.hpp
+++ b/src/hotspot/cpu/riscv/globals_riscv.hpp
@@ -92,6 +92,7 @@ define_pd_global(intx, InlineSmallCode,          1000);
           "Avoid generating unaligned memory accesses")                          \
   product(bool, UseRVV, false, EXPERIMENTAL, "Use RVV instructions")             \
   product(bool, UseRVB, false, EXPERIMENTAL, "Use RVB instructions")             \
-  product(bool, UseRVC, false, EXPERIMENTAL, "Use RVC instructions")
-
+  product(bool, UseRVC, false, EXPERIMENTAL, "Use RVC instructions")             \
+  product(bool, UseRVVForBigIntegerShiftIntrinsics, true,                        \
+          "Use RVV instructions for left/right shift of BigInteger")
 #endif // CPU_RISCV_GLOBALS_RISCV_HPP

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2865,7 +2865,7 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_bigIntegerLeftShift() {
     __ align(CodeEntryAlignment);
-    StubCodeMark mark(this,  "StubRoutines", "bigIntegerLeftShiftWorker");
+    StubCodeMark mark(this, "StubRoutines", "bigIntegerLeftShiftWorker");
     address entry = __ pc();
 
     Label loop, exit;
@@ -2895,14 +2895,8 @@ class StubGenerator: public StubCodeGenerator {
     __ vor_vv(v0, v0, v4);
     __ vse32_v(v0, newArr);
     __ sub(numIter, numIter, t0);
-    if (UseRVB) {
-      __ sh2add(oldArr, t0, oldArr);
-      __ sh2add(newArr, t0, newArr);
-    } else {
-      __ slli(t0, t0, 2);
-      __ add(oldArr, oldArr, t0);
-      __ add(newArr, newArr, t0);
-    }
+    __ shadd(oldArr, t0, oldArr, t1, 2);
+    __ shadd(newArr, t0, oldArr, t1, 2);
     __ bnez(numIter, loop);
 
     __ bind(exit);
@@ -3777,7 +3771,7 @@ class StubGenerator: public StubCodeGenerator {
     }
 
     if (UseRVV) {
-      StubRoutines::_bigIntegerLeftShiftWorker  = generate_bigIntegerLeftShift();
+      StubRoutines::_bigIntegerLeftShiftWorker = generate_bigIntegerLeftShift();
     }
 #endif
 

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -3770,7 +3770,7 @@ class StubGenerator: public StubCodeGenerator {
       StubRoutines::_montgomerySquare = g.generate_square();
     }
 
-    if (UseRVV) {
+    if (UseRVVForBigIntegerShiftIntrinsics) {
       StubRoutines::_bigIntegerLeftShiftWorker = generate_bigIntegerLeftShift();
     }
 #endif

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2896,7 +2896,7 @@ class StubGenerator: public StubCodeGenerator {
     __ vse32_v(v0, newArr);
     __ sub(numIter, numIter, t0);
     __ shadd(oldArr, t0, oldArr, t1, 2);
-    __ shadd(newArr, t0, oldArr, t1, 2);
+    __ shadd(newArr, t0, newArr, t1, 2);
     __ bnez(numIter, loop);
 
     __ bind(exit);

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2853,6 +2853,63 @@ class StubGenerator: public StubCodeGenerator {
 
     return entry;
   }
+
+  // Arguments:
+  //
+  // Input:
+  //   c_rarg0   - newArr address
+  //   c_rarg1   - oldArr address
+  //   c_rarg2   - newIdx
+  //   c_rarg3   - shiftCount
+  //   c_rarg4   - numIter
+  //
+  address generate_bigIntegerLeftShift() {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this,  "StubRoutines", "bigIntegerLeftShiftWorker");
+    address entry = __ pc();
+
+    Label loop, exit;
+
+    Register newArr        = c_rarg0;
+    Register oldArr        = c_rarg1;
+    Register newIdx        = c_rarg2;
+    Register shiftCount    = c_rarg3;
+    Register numIter       = c_rarg4;
+
+    Register shiftRevCount = c_rarg5;
+    Register oldArrNext    = t1;
+
+    __ beqz(numIter, exit);
+    __ shadd(newArr, newIdx, newArr, t0, 2);
+
+    __ li(shiftRevCount, 32);
+    __ sub(shiftRevCount, shiftRevCount, shiftCount);
+
+    __ bind(loop);
+    __ addi(oldArrNext, oldArr, 4);
+    __ vsetvli(t0, numIter, Assembler::e32, Assembler::m4);
+    __ vle32_v(v0, oldArr);
+    __ vle32_v(v4, oldArrNext);
+    __ vsll_vx(v0, v0, shiftCount);
+    __ vsrl_vx(v4, v4, shiftRevCount);
+    __ vor_vv(v0, v0, v4);
+    __ vse32_v(v0, newArr);
+    __ sub(numIter, numIter, t0);
+    if (UseRVB) {
+      __ sh2add(oldArr, t0, oldArr);
+      __ sh2add(newArr, t0, newArr);
+    } else {
+      __ slli(t0, t0, 2);
+      __ add(oldArr, oldArr, t0);
+      __ add(newArr, newArr, t0);
+    }
+    __ bnez(numIter, loop);
+
+    __ bind(exit);
+    __ ret();
+
+    return entry;
+  }
 #endif
 
 #ifdef COMPILER2
@@ -3717,6 +3774,10 @@ class StubGenerator: public StubCodeGenerator {
       StubCodeMark mark(this, "StubRoutines", "montgomerySquare");
       MontgomeryMultiplyGenerator g(_masm, /*squaring*/true);
       StubRoutines::_montgomerySquare = g.generate_square();
+    }
+
+    if (UseRVV) {
+      StubRoutines::_bigIntegerLeftShiftWorker  = generate_bigIntegerLeftShift();
     }
 #endif
 

--- a/src/hotspot/cpu/riscv/vm_version_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vm_version_riscv.cpp
@@ -167,6 +167,10 @@ void VM_Version::c2_initialize() {
     FLAG_SET_DEFAULT(MaxVectorSize, 0);
   }
 
+  if (!UseRVV) {
+    FLAG_SET_DEFAULT(UseRVVForBigIntegerShiftIntrinsics, false);
+  }
+
   if (UseRVV) {
     if (FLAG_IS_DEFAULT(MaxVectorSize)) {
       MaxVectorSize = _initial_vector_length;


### PR DESCRIPTION
BigInteger intrinsic: bigIntegerLeftShift intrinsic is missed in current vm. It should be implemented.
Since that there is no hardware that supports rvv1.0 for now, I used `test/jdk/java/math/BigInteger/ModPow.java` testcase to compare the number of instructions executed with and without intrinsic. The number of instructions executed for the method `shiftLeftImplWorker` compiled by C2 without intrinsic is about 9.2x ( vlen=256 ) that of version with intrinsic.

Full jtreg tests on qemu are passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8281967](https://bugs.openjdk.java.net/browse/JDK-8281967): riscv: Intrinsify BigIntegerLeftShift


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)
 * [Yanhong Zhu](https://openjdk.java.net/census#yzhu) (@yhzhu20 - Committer) ⚠️ Review applies to 43ed654c32f64f431183a72295fe879ba40f725e


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/61/head:pull/61` \
`$ git checkout pull/61`

Update a local copy of the PR: \
`$ git checkout pull/61` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/61/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 61`

View PR using the GUI difftool: \
`$ git pr show -t 61`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/61.diff">https://git.openjdk.java.net/riscv-port/pull/61.diff</a>

</details>
