### PR TITLE
8282466: riscv: Remove unused code in linux_riscv

### DIFF
--- a/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
+++ b/src/hotspot/cpu/riscv/abstractInterpreter_riscv.cpp
@@ -101,7 +101,7 @@ int AbstractInterpreter::size_activation(int max_stack,
              // frame do we need to allow max_stack words.
              (is_top_frame ? max_stack : temps + extra_args);
 
-  // On riscv64 we always keep the stack pointer 16-aligned, so we
+  // On riscv we always keep the stack pointer 16-aligned, so we
   // must round up here.
   size = align_up(size, 2);
 

--- a/src/hotspot/cpu/riscv/assembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/assembler_riscv.hpp
@@ -3034,7 +3034,7 @@ public:
     return is_imm_in_range(imm, 12, 0);
   }
 
-  // The maximum range of a branch is fixed for the riscv64
+  // The maximum range of a branch is fixed for the riscv
   // architecture.
   static const unsigned long branch_range = 1 * M;
 

--- a/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_CodeStubs_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -261,10 +261,10 @@ int PatchingStub::_patch_info_offset = -NativeGeneralJump::instruction_size;
 
 void PatchingStub::align_patch_site(MacroAssembler* masm) {}
 
-// RISCV64 don't use C1 runtime patching. When need patch, just deoptimize.
+// RISCV don't use C1 runtime patching. When need patch, just deoptimize.
 void PatchingStub::emit_code(LIR_Assembler* ce)
 {
-  assert(false, "RISCV64 should not use C1 runtime patching");
+  assert(false, "RISCV should not use C1 runtime patching");
 }
 
 void DeoptimizeStub::emit_code(LIR_Assembler* ce)

--- a/src/hotspot/cpu/riscv/c1_Defs_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_Defs_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -76,7 +76,7 @@ enum {
 
 // Encoding of float value in debug info.  This is true on x86 where
 // floats are extended to doubles when stored in the stack, false for
-// RISCV64 where floats and doubles are stored in their native form.
+// RISCV where floats and doubles are stored in their native form.
 enum {
   pd_float_saved_as_double = false
 };

--- a/src/hotspot/cpu/riscv/c1_FpuStackSim_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_FpuStackSim_riscv.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005, 2017, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,4 +27,4 @@
 //               FpuStackSim
 //--------------------------------------------------------
 
-// No FPU stack on RISCV64
+// No FPU stack on RISCV

--- a/src/hotspot/cpu/riscv/c1_FpuStackSim_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_FpuStackSim_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2005, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 #ifndef CPU_RISCV_C1_FPUSTACKSIM_RISCV_HPP
 #define CPU_RISCV_C1_FPUSTACKSIM_RISCV_HPP
 
-// No FPU stack on RISCV64
+// No FPU stack on RISCV
 class FpuStackSim;
 
 #endif // CPU_RISCV_C1_FPUSTACKSIM_RISCV_HPP

--- a/src/hotspot/cpu/riscv/c1_FrameMap_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c1_FrameMap_riscv.cpp
@@ -380,7 +380,7 @@ LIR_Opr FrameMap::stack_pointer() {
 
 // JSR 292
 LIR_Opr FrameMap::method_handle_invoke_SP_save_opr() {
-  return LIR_OprFact::illegalOpr;  // Not needed on riscv64
+  return LIR_OprFact::illegalOpr;  // Not needed on riscv
 }
 
 bool FrameMap::validate_frame() {

--- a/src/hotspot/cpu/riscv/c1_FrameMap_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c1_FrameMap_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -26,7 +26,7 @@
 #ifndef CPU_RISCV_C1_FRAMEMAP_RISCV_HPP
 #define CPU_RISCV_C1_FRAMEMAP_RISCV_HPP
 
-//  On RISCV64 the frame looks as follows:
+//  On RISCV the frame looks as follows:
 //
 //  +-----------------------------+---------+----------------------------------------+----------------+-----------
 //  | size_arguments-nof_reg_args | 2 words | size_locals-size_arguments+numreg_args | _size_monitors | spilling .

--- a/src/hotspot/cpu/riscv/c2_init_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_init_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, 2019, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 #include "opto/compile.hpp"
 #include "opto/node.hpp"
 
-// processor dependent initialization for riscv64
+// processor dependent initialization for riscv
 
 extern void reg_mask_init();
 

--- a/src/hotspot/cpu/riscv/disassembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/disassembler_riscv.hpp
@@ -36,7 +36,7 @@
 
 // Returns address of n-th instruction preceding addr,
 // NULL if no preceding instruction can be found.
-// On (riscv64), we assume a constant instruction length.
+// On riscv, we assume a constant instruction length.
 // It might be beneficial to check "is_readable" as we do on ppc and s390.
 static address find_prev_instr(address addr, int n_instr) {
   return addr - Assembler::instruction_size * n_instr;

--- a/src/hotspot/cpu/riscv/frame_riscv.cpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.cpp
@@ -388,7 +388,7 @@ void frame::verify_deopt_original_pc(CompiledMethod* nm, intptr_t* unextended_sp
 //------------------------------------------------------------------------------
 // frame::adjust_unextended_sp
 void frame::adjust_unextended_sp() {
-  // On riscv64, sites calling method handle intrinsics and lambda forms are treated
+  // On riscv, sites calling method handle intrinsics and lambda forms are treated
   // as any other call site. Therefore, no special action is needed when we are
   // returning to any of these call sites.
 
@@ -651,7 +651,7 @@ void frame::describe_pd(FrameValues& values, int frame_no) {
 #endif
 
 intptr_t *frame::initial_deoptimization_info() {
-  // Not used on riscv64, but we must return something.
+  // Not used on riscv, but we must return something.
   return NULL;
 }
 

--- a/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
+++ b/src/hotspot/cpu/riscv/frame_riscv.inline.hpp
@@ -30,7 +30,7 @@
 #include "code/codeCache.hpp"
 #include "code/vmreg.inline.hpp"
 
-// Inline functions for RISCV64 frames:
+// Inline functions for RISCV frames:
 
 // Constructors:
 

--- a/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
+++ b/src/hotspot/cpu/riscv/interp_masm_riscv.cpp
@@ -224,7 +224,7 @@ void InterpreterMacroAssembler::get_cache_and_index_at_bcp(Register cache,
   get_cache_index_at_bcp(index, bcp_offset, index_size);
   assert(sizeof(ConstantPoolCacheEntry) == 4 * wordSize, "adjust code below");
   // Convert from field index to ConstantPoolCacheEntry
-  // riscv64 already has the cache in xcpool so there is no need to
+  // riscv already has the cache in xcpool so there is no need to
   // install it in cache. Instead we pre-add the indexed offset to
   // xcpool and return it in cache. All clients of this method need to
   // be modified accordingly.

--- a/src/hotspot/cpu/riscv/matcher_riscv.hpp
+++ b/src/hotspot/cpu/riscv/matcher_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2021, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -38,7 +38,7 @@
     return UseRVV;
   }
 
-  // riscv64 supports misaligned vectors store/load.
+  // riscv supports misaligned vectors store/load.
   static constexpr bool misaligned_vectors_ok() {
     return true;
   }

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.cpp
@@ -353,7 +353,7 @@ void NativeJump::patch_verified_entry(address entry, address verified_entry, add
 
   assert(nativeInstruction_at(verified_entry)->is_jump_or_nop() ||
          nativeInstruction_at(verified_entry)->is_sigill_zombie_not_entrant(),
-         "riscv64 cannot replace non-jump with jump");
+         "riscv cannot replace non-jump with jump");
 
   // Patch this nmethod atomically.
   if (Assembler::reachable_from_branch_at(verified_entry, dest)) {

--- a/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
+++ b/src/hotspot/cpu/riscv/nativeInst_riscv.hpp
@@ -234,7 +234,7 @@ inline NativeInstruction* nativeInstruction_at(address addr) {
   return (NativeInstruction*)addr;
 }
 
-// The natural type of an RISCV64 instruction is uint32_t
+// The natural type of an RISCV instruction is uint32_t
 inline NativeInstruction* nativeInstruction_at(uint32_t *addr) {
   return (NativeInstruction*)addr;
 }
@@ -246,7 +246,7 @@ inline NativeCall* nativeCall_at(address addr);
 
 class NativeCall: public NativeInstruction {
  public:
-  enum RISCV64_specific_constants {
+  enum RISCV_specific_constants {
     instruction_size            =    4,
     instruction_offset          =    0,
     displacement_offset         =    0,
@@ -330,7 +330,7 @@ inline NativeCall* nativeCall_before(address return_address) {
 // (used to manipulate inlined 64-bit data calls, etc.)
 class NativeMovConstReg: public NativeInstruction {
  public:
-  enum RISCV64_specific_constants {
+  enum RISCV_specific_constants {
     movptr_instruction_size             =    6 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli, addi.  See movptr().
     movptr_with_offset_instruction_size =    5 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli. See movptr_with_offset().
     load_pc_relative_instruction_size   =    2 * NativeInstruction::instruction_size, // auipc, ld
@@ -396,7 +396,7 @@ inline NativeMovConstReg* nativeMovConstReg_before(address addr) {
   return test;
 }
 
-// RISCV64 should not use C1 runtime patching, so just leave NativeMovRegMem Unimplemented.
+// RISCV should not use C1 runtime patching, so just leave NativeMovRegMem Unimplemented.
 class NativeMovRegMem: public NativeInstruction {
  public:
   int instruction_start() const {
@@ -434,7 +434,7 @@ inline NativeMovRegMem* nativeMovRegMem_at (address addr) {
 
 class NativeJump: public NativeInstruction {
  public:
-  enum RISCV64_specific_constants {
+  enum RISCV_specific_constants {
     instruction_size            =    NativeInstruction::instruction_size,
     instruction_offset          =    0,
     data_offset                 =    0,
@@ -468,7 +468,7 @@ inline NativeJump* nativeJump_at(address addr) {
 
 class NativeGeneralJump: public NativeJump {
 public:
-  enum RISCV64_specific_constants {
+  enum RISCV_specific_constants {
     instruction_size            =    6 * NativeInstruction::instruction_size, // lui, addi, slli, addi, slli, jalr
     instruction_offset          =    0,
     data_offset                 =    0,
@@ -507,7 +507,7 @@ inline bool NativeInstruction::is_jump_or_nop() {
 class NativeCallTrampolineStub : public NativeInstruction {
  public:
 
-  enum RISCV64_specific_constants {
+  enum RISCV_specific_constants {
     // Refer to function emit_trampoline_stub.
     instruction_size = 3 * NativeInstruction::instruction_size + wordSize, // auipc + ld + jr + target address
     data_offset      = 3 * NativeInstruction::instruction_size,            // auipc + ld + jr

--- a/src/hotspot/cpu/riscv/register_riscv.hpp
+++ b/src/hotspot/cpu/riscv/register_riscv.hpp
@@ -97,7 +97,7 @@ class RegisterImpl: public AbstractRegisterImpl {
 
 REGISTER_IMPL_DECLARATION(Register, RegisterImpl, RegisterImpl::number_of_registers);
 
-// The integer registers of the RISCV64 architecture
+// The integer registers of the RISCV architecture
 
 CONSTANT_REGISTER_DECLARATION(Register, noreg, (-1));
 
@@ -188,7 +188,7 @@ class FloatRegisterImpl: public AbstractRegisterImpl {
 
 REGISTER_IMPL_DECLARATION(FloatRegister, FloatRegisterImpl, FloatRegisterImpl::number_of_registers);
 
-// The float registers of the RISCV64 architecture
+// The float registers of the RISCV architecture
 
 CONSTANT_REGISTER_DECLARATION(FloatRegister, fnoreg , (-1));
 

--- a/src/hotspot/cpu/riscv/riscv.ad
+++ b/src/hotspot/cpu/riscv/riscv.ad
@@ -24,7 +24,7 @@
 //
 //
 
-// RISCV64 Architecture Description File
+// RISCV Architecture Description File
 
 //----------REGISTER DEFINITION BLOCK------------------------------------------
 // This information is used by the matcher and the register allocator to
@@ -154,7 +154,7 @@ reg_def R31_H   ( SOC, SOC, Op_RegI, 31, x31->as_VMReg()->next());
 // CPU stores such a register pair to memory, the word associated with
 // the lower ADLC-assigned number must be stored to the lower address.
 
-// RISCV64 has 32 floating-point registers. Each can store a single
+// RISCV has 32 floating-point registers. Each can store a single
 // or double precision floating-point value.
 
 // for Java use float registers f0-f31 are always save on call whereas
@@ -1171,7 +1171,7 @@ int MachCallRuntimeNode::ret_addr_offset() {
   // or with far branches
   //   jal(trampoline_stub)
   // for real runtime callouts it will be 11 instructions
-  // see riscv64_enc_java_to_runtime
+  // see riscv_enc_java_to_runtime
   //   la(t1, retaddr)                ->  auipc + addi
   //   la(t0, RuntimeAddress(addr))   ->  lui + addi + slli + addi + slli + addi
   //   addi(sp, sp, -2 * wordSize)    ->  addi
@@ -2073,7 +2073,7 @@ bool Matcher::pd_clone_address_expressions(AddPNode* m, Matcher::MStack& mstack,
 encode %{
   // BEGIN Non-volatile memory access
 
-  enc_class riscv64_enc_li_imm(iRegIorL dst, immIorL src) %{
+  enc_class riscv_enc_li_imm(iRegIorL dst, immIorL src) %{
     C2_MacroAssembler _masm(&cbuf);
     Assembler::CompressibleRegion cr(&_masm);
     int64_t con = (int64_t)$src$$constant;
@@ -2081,7 +2081,7 @@ encode %{
     __ li(dst_reg, con);
   %}
 
-  enc_class riscv64_enc_mov_p(iRegP dst, immP src) %{
+  enc_class riscv_enc_mov_p(iRegP dst, immP src) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
@@ -2100,19 +2100,19 @@ encode %{
     }
   %}
 
-  enc_class riscv64_enc_mov_p1(iRegP dst) %{
+  enc_class riscv_enc_mov_p1(iRegP dst) %{
     C2_MacroAssembler _masm(&cbuf);
     Assembler::CompressibleRegion cr(&_masm);
     Register dst_reg = as_Register($dst$$reg);
     __ li(dst_reg, 1);
   %}
 
-  enc_class riscv64_enc_mov_byte_map_base(iRegP dst) %{
+  enc_class riscv_enc_mov_byte_map_base(iRegP dst) %{
     C2_MacroAssembler _masm(&cbuf);
     __ load_byte_map_base($dst$$Register);
   %}
 
-  enc_class riscv64_enc_mov_n(iRegN dst, immN src) %{
+  enc_class riscv_enc_mov_n(iRegN dst, immN src) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
@@ -2125,13 +2125,13 @@ encode %{
     }
   %}
 
-  enc_class riscv64_enc_mov_zero(iRegNorP dst) %{
+  enc_class riscv_enc_mov_zero(iRegNorP dst) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     __ mv(dst_reg, zr);
   %}
 
-  enc_class riscv64_enc_mov_nk(iRegN dst, immNKlass src) %{
+  enc_class riscv_enc_mov_nk(iRegN dst, immNKlass src) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     address con = (address)$src$$constant;
@@ -2144,42 +2144,42 @@ encode %{
     }
   %}
 
-  enc_class riscv64_enc_cmpxchgw(iRegINoSp res, memory mem, iRegINoSp oldval, iRegINoSp newval) %{
+  enc_class riscv_enc_cmpxchgw(iRegINoSp res, memory mem, iRegINoSp oldval, iRegINoSp newval) %{
     C2_MacroAssembler _masm(&cbuf);
     __ cmpxchg(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int32,
                /*acquire*/ Assembler::relaxed, /*release*/ Assembler::rl, $res$$Register,
                /*result as bool*/ true);
   %}
 
-  enc_class riscv64_enc_cmpxchgn(iRegINoSp res, memory mem, iRegINoSp oldval, iRegINoSp newval) %{
+  enc_class riscv_enc_cmpxchgn(iRegINoSp res, memory mem, iRegINoSp oldval, iRegINoSp newval) %{
     C2_MacroAssembler _masm(&cbuf);
     __ cmpxchg(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::uint32,
                /*acquire*/ Assembler::relaxed, /*release*/ Assembler::rl, $res$$Register,
                /*result as bool*/ true);
   %}
 
-  enc_class riscv64_enc_cmpxchg(iRegINoSp res, memory mem, iRegLNoSp oldval, iRegLNoSp newval) %{
+  enc_class riscv_enc_cmpxchg(iRegINoSp res, memory mem, iRegLNoSp oldval, iRegLNoSp newval) %{
     C2_MacroAssembler _masm(&cbuf);
     __ cmpxchg(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int64,
                /*acquire*/ Assembler::relaxed, /*release*/ Assembler::rl, $res$$Register,
                /*result as bool*/ true);
   %}
 
-  enc_class riscv64_enc_cmpxchgw_acq(iRegINoSp res, memory mem, iRegINoSp oldval, iRegINoSp newval) %{
+  enc_class riscv_enc_cmpxchgw_acq(iRegINoSp res, memory mem, iRegINoSp oldval, iRegINoSp newval) %{
     C2_MacroAssembler _masm(&cbuf);
     __ cmpxchg(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int32,
                /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register,
                /*result as bool*/ true);
   %}
 
-  enc_class riscv64_enc_cmpxchgn_acq(iRegINoSp res, memory mem, iRegINoSp oldval, iRegINoSp newval) %{
+  enc_class riscv_enc_cmpxchgn_acq(iRegINoSp res, memory mem, iRegINoSp oldval, iRegINoSp newval) %{
     C2_MacroAssembler _masm(&cbuf);
     __ cmpxchg(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::uint32,
                /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register,
                /*result as bool*/ true);
   %}
 
-  enc_class riscv64_enc_cmpxchg_acq(iRegINoSp res, memory mem, iRegLNoSp oldval, iRegLNoSp newval) %{
+  enc_class riscv_enc_cmpxchg_acq(iRegINoSp res, memory mem, iRegLNoSp oldval, iRegLNoSp newval) %{
     C2_MacroAssembler _masm(&cbuf);
     __ cmpxchg(as_Register($mem$$base), $oldval$$Register, $newval$$Register, Assembler::int64,
                /*acquire*/ Assembler::aq, /*release*/ Assembler::rl, $res$$Register,
@@ -2188,13 +2188,13 @@ encode %{
 
   // compare and branch instruction encodings
 
-  enc_class riscv64_enc_j(label lbl) %{
+  enc_class riscv_enc_j(label lbl) %{
     C2_MacroAssembler _masm(&cbuf);
     Label* L = $lbl$$label;
     __ j(*L);
   %}
 
-  enc_class riscv64_enc_far_cmpULtGe_imm0_branch(cmpOpULtGe cmp, iRegIorL op1, label lbl) %{
+  enc_class riscv_enc_far_cmpULtGe_imm0_branch(cmpOpULtGe cmp, iRegIorL op1, label lbl) %{
     C2_MacroAssembler _masm(&cbuf);
     Label* L = $lbl$$label;
     switch ($cmp$$cmpcode) {
@@ -2210,7 +2210,7 @@ encode %{
 
   // call instruction encodings
 
-  enc_class riscv64_enc_partial_subtype_check(iRegP sub, iRegP super, iRegP temp, iRegP result) %{
+  enc_class riscv_enc_partial_subtype_check(iRegP sub, iRegP super, iRegP temp, iRegP result) %{
     Register sub_reg = as_Register($sub$$reg);
     Register super_reg = as_Register($super$$reg);
     Register temp_reg = as_Register($temp$$reg);
@@ -2237,7 +2237,7 @@ encode %{
     __ bind(done);
   %}
 
-  enc_class riscv64_enc_java_static_call(method meth) %{
+  enc_class riscv_enc_java_static_call(method meth) %{
     C2_MacroAssembler _masm(&cbuf);
 
     address addr = (address)$meth$$method;
@@ -2269,7 +2269,7 @@ encode %{
     }
   %}
 
-  enc_class riscv64_enc_java_dynamic_call(method meth) %{
+  enc_class riscv_enc_java_dynamic_call(method meth) %{
     C2_MacroAssembler _masm(&cbuf);
     int method_index = resolved_method_index(cbuf);
     address call = __ ic_call((address)$meth$$method, method_index);
@@ -2279,7 +2279,7 @@ encode %{
     }
   %}
 
-  enc_class riscv64_enc_call_epilog() %{
+  enc_class riscv_enc_call_epilog() %{
     C2_MacroAssembler _masm(&cbuf);
     if (VerifyStackAtCalls) {
       // Check that stack depth is unchanged: find majik cookie on stack
@@ -2287,7 +2287,7 @@ encode %{
     }
   %}
 
-  enc_class riscv64_enc_java_to_runtime(method meth) %{
+  enc_class riscv_enc_java_to_runtime(method meth) %{
     C2_MacroAssembler _masm(&cbuf);
 
     // some calls to generated routines (arraycopy code) are scheduled
@@ -2316,7 +2316,7 @@ encode %{
   %}
 
   // using the cr register as the bool result: 0 for success; others failed.
-  enc_class riscv64_enc_fast_lock(iRegP object, iRegP box, iRegP tmp1, iRegP tmp2) %{
+  enc_class riscv_enc_fast_lock(iRegP object, iRegP box, iRegP tmp1, iRegP tmp2) %{
     C2_MacroAssembler _masm(&cbuf);
     Register flag = t1;
     Register oop = as_Register($object$$reg);
@@ -2410,7 +2410,7 @@ encode %{
   %}
 
   // using cr flag to indicate the fast_unlock result: 0 for success; others failed.
-  enc_class riscv64_enc_fast_unlock(iRegP object, iRegP box, iRegP tmp1, iRegP tmp2) %{
+  enc_class riscv_enc_fast_unlock(iRegP object, iRegP box, iRegP tmp1, iRegP tmp2) %{
     C2_MacroAssembler _masm(&cbuf);
     Register flag = t1;
     Register oop = as_Register($object$$reg);
@@ -2481,7 +2481,7 @@ encode %{
 
   // arithmetic encodings
 
-  enc_class riscv64_enc_divw(iRegI dst, iRegI src1, iRegI src2) %{
+  enc_class riscv_enc_divw(iRegI dst, iRegI src1, iRegI src2) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
@@ -2489,7 +2489,7 @@ encode %{
     __ corrected_idivl(dst_reg, src1_reg, src2_reg, false);
   %}
 
-  enc_class riscv64_enc_div(iRegI dst, iRegI src1, iRegI src2) %{
+  enc_class riscv_enc_div(iRegI dst, iRegI src1, iRegI src2) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
@@ -2497,7 +2497,7 @@ encode %{
     __ corrected_idivq(dst_reg, src1_reg, src2_reg, false);
   %}
 
-  enc_class riscv64_enc_modw(iRegI dst, iRegI src1, iRegI src2) %{
+  enc_class riscv_enc_modw(iRegI dst, iRegI src1, iRegI src2) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
@@ -2505,7 +2505,7 @@ encode %{
     __ corrected_idivl(dst_reg, src1_reg, src2_reg, true);
   %}
 
-  enc_class riscv64_enc_mod(iRegI dst, iRegI src1, iRegI src2) %{
+  enc_class riscv_enc_mod(iRegI dst, iRegI src1, iRegI src2) %{
     C2_MacroAssembler _masm(&cbuf);
     Register dst_reg = as_Register($dst$$reg);
     Register src1_reg = as_Register($src1$$reg);
@@ -2513,14 +2513,14 @@ encode %{
     __ corrected_idivq(dst_reg, src1_reg, src2_reg, true);
   %}
 
-  enc_class riscv64_enc_tail_call(iRegP jump_target) %{
+  enc_class riscv_enc_tail_call(iRegP jump_target) %{
     C2_MacroAssembler _masm(&cbuf);
     Assembler::CompressibleRegion cr(&_masm);
     Register target_reg = as_Register($jump_target$$reg);
     __ jr(target_reg);
   %}
 
-  enc_class riscv64_enc_tail_jmp(iRegP jump_target) %{
+  enc_class riscv_enc_tail_jmp(iRegP jump_target) %{
     C2_MacroAssembler _masm(&cbuf);
     Assembler::CompressibleRegion cr(&_masm);
     Register target_reg = as_Register($jump_target$$reg);
@@ -2531,12 +2531,12 @@ encode %{
     __ jr(target_reg);
   %}
 
-  enc_class riscv64_enc_rethrow() %{
+  enc_class riscv_enc_rethrow() %{
     C2_MacroAssembler _masm(&cbuf);
     __ far_jump(RuntimeAddress(OptoRuntime::rethrow_stub()));
   %}
 
-  enc_class riscv64_enc_ret() %{
+  enc_class riscv_enc_ret() %{
     C2_MacroAssembler _masm(&cbuf);
     Assembler::CompressibleRegion cr(&_masm);
     __ ret();
@@ -2595,7 +2595,7 @@ encode %{
 // Note 3: Region 0-3 is even aligned, with pad2 as needed.  Region 3-5 is
 //         even aligned with pad0 as needed.
 //         Region 6 is even aligned.  Region 6-7 is NOT even aligned;
-//           (the latter is true on Intel but is it false on RISCV64?)
+//           (the latter is true on Intel but is it false on RISCV?)
 //         region 6-11 is even aligned; it may be padded out more so that
 //         the region from SP to FP meets the minimum stack alignment.
 // Note 4: For I2C adapters, the incoming FP may not meet the minimum stack
@@ -3541,7 +3541,7 @@ operand indOffLN(iRegN reg, immLOffset off)
   %}
 %}
 
-// RISCV64 opto stubs need to write to the pc slot in the thread anchor
+// RISCV opto stubs need to write to the pc slot in the thread anchor
 operand thread_anchor_pc(javaThread_RegP reg, immL_pc_off off)
 %{
   constraint(ALLOC_IN_RC(ptr_reg));
@@ -4694,7 +4694,7 @@ instruct loadConI(iRegINoSp dst, immI src)
   ins_cost(ALU_COST);
   format %{ "li $dst, $src\t# int, #@loadConI" %}
 
-  ins_encode(riscv64_enc_li_imm(dst, src));
+  ins_encode(riscv_enc_li_imm(dst, src));
 
   ins_pipe(ialu_imm);
 %}
@@ -4707,7 +4707,7 @@ instruct loadConL(iRegLNoSp dst, immL src)
   ins_cost(ALU_COST);
   format %{ "li $dst, $src\t# long, #@loadConL" %}
 
-  ins_encode(riscv64_enc_li_imm(dst, src));
+  ins_encode(riscv_enc_li_imm(dst, src));
 
   ins_pipe(ialu_imm);
 %}
@@ -4720,7 +4720,7 @@ instruct loadConP(iRegPNoSp dst, immP con)
   ins_cost(ALU_COST);
   format %{ "mv  $dst, $con\t# ptr, #@loadConP" %}
 
-  ins_encode(riscv64_enc_mov_p(dst, con));
+  ins_encode(riscv_enc_mov_p(dst, con));
 
   ins_pipe(ialu_imm);
 %}
@@ -4733,7 +4733,7 @@ instruct loadConP0(iRegPNoSp dst, immP0 con)
   ins_cost(ALU_COST);
   format %{ "mv  $dst, $con\t# NULL ptr, #@loadConP0" %}
 
-  ins_encode(riscv64_enc_mov_zero(dst));
+  ins_encode(riscv_enc_mov_zero(dst));
 
   ins_pipe(ialu_imm);
 %}
@@ -4746,7 +4746,7 @@ instruct loadConP1(iRegPNoSp dst, immP_1 con)
   ins_cost(ALU_COST);
   format %{ "mv  $dst, $con\t# load ptr constant one, #@loadConP1" %}
 
-  ins_encode(riscv64_enc_mov_p1(dst));
+  ins_encode(riscv_enc_mov_p1(dst));
 
   ins_pipe(ialu_imm);
 %}
@@ -4758,7 +4758,7 @@ instruct loadByteMapBase(iRegPNoSp dst, immByteMapBase con)
   ins_cost(ALU_COST);
   format %{ "mv  $dst, $con\t# Byte Map Base, #@loadByteMapBase" %}
 
-  ins_encode(riscv64_enc_mov_byte_map_base(dst));
+  ins_encode(riscv_enc_mov_byte_map_base(dst));
 
   ins_pipe(ialu_imm);
 %}
@@ -4771,7 +4771,7 @@ instruct loadConN(iRegNNoSp dst, immN con)
   ins_cost(ALU_COST * 4);
   format %{ "mv  $dst, $con\t# compressed ptr, #@loadConN" %}
 
-  ins_encode(riscv64_enc_mov_n(dst, con));
+  ins_encode(riscv_enc_mov_n(dst, con));
 
   ins_pipe(ialu_imm);
 %}
@@ -4784,7 +4784,7 @@ instruct loadConN0(iRegNNoSp dst, immN0 con)
   ins_cost(ALU_COST);
   format %{ "mv  $dst, $con\t# compressed NULL ptr, #@loadConN0" %}
 
-  ins_encode(riscv64_enc_mov_zero(dst));
+  ins_encode(riscv_enc_mov_zero(dst));
 
   ins_pipe(ialu_imm);
 %}
@@ -4797,7 +4797,7 @@ instruct loadConNKlass(iRegNNoSp dst, immNKlass con)
   ins_cost(ALU_COST * 6);
   format %{ "mv  $dst, $con\t# compressed klass ptr, #@loadConNKlass" %}
 
-  ins_encode(riscv64_enc_mov_nk(dst, con));
+  ins_encode(riscv_enc_mov_nk(dst, con));
 
   ins_pipe(ialu_imm);
 %}
@@ -5141,7 +5141,7 @@ instruct storeNKlass(iRegN src, memory mem)
 // only for 64-bit.
 //
 // We implement LoadPLocked and storePConditional instructions using,
-// respectively the RISCV64 hw load-reserve and store-conditional
+// respectively the RISCV hw load-reserve and store-conditional
 // instructions. Whereas we must implement each of
 // Store{IL}Conditional using a CAS which employs a pair of
 // instructions comprising a load-reserve followed by a
@@ -5289,7 +5289,7 @@ instruct compareAndSwapI(iRegINoSp res, indirect mem, iRegINoSp oldval, iRegINoS
     "mv $res, $res == $oldval\t# $res <-- ($res == $oldval ? 1 : 0), #@compareAndSwapI"
   %}
 
-  ins_encode(riscv64_enc_cmpxchgw(res, mem, oldval, newval));
+  ins_encode(riscv_enc_cmpxchgw(res, mem, oldval, newval));
 
   ins_pipe(pipe_slow);
 %}
@@ -5305,7 +5305,7 @@ instruct compareAndSwapL(iRegINoSp res, indirect mem, iRegLNoSp oldval, iRegLNoS
     "mv $res, $res == $oldval\t# $res <-- ($res == $oldval ? 1 : 0), #@compareAndSwapL"
   %}
 
-  ins_encode(riscv64_enc_cmpxchg(res, mem, oldval, newval));
+  ins_encode(riscv_enc_cmpxchg(res, mem, oldval, newval));
 
   ins_pipe(pipe_slow);
 %}
@@ -5323,7 +5323,7 @@ instruct compareAndSwapP(iRegINoSp res, indirect mem, iRegP oldval, iRegP newval
     "mv $res, $res == $oldval\t# $res <-- ($res == $oldval ? 1 : 0), #@compareAndSwapP"
   %}
 
-  ins_encode(riscv64_enc_cmpxchg(res, mem, oldval, newval));
+  ins_encode(riscv_enc_cmpxchg(res, mem, oldval, newval));
 
   ins_pipe(pipe_slow);
 %}
@@ -5339,7 +5339,7 @@ instruct compareAndSwapN(iRegINoSp res, indirect mem, iRegNNoSp oldval, iRegNNoS
     "mv $res, $res == $oldval\t# $res <-- ($res == $oldval ? 1 : 0), #@compareAndSwapN"
   %}
 
-  ins_encode(riscv64_enc_cmpxchgn(res, mem, oldval, newval));
+  ins_encode(riscv_enc_cmpxchgn(res, mem, oldval, newval));
 
   ins_pipe(pipe_slow);
 %}
@@ -5408,7 +5408,7 @@ instruct compareAndSwapIAcq(iRegINoSp res, indirect mem, iRegINoSp oldval, iRegI
     "mv $res, $res == $oldval\t# $res <-- ($res == $oldval ? 1 : 0), #@compareAndSwapIAcq"
   %}
 
-  ins_encode(riscv64_enc_cmpxchgw_acq(res, mem, oldval, newval));
+  ins_encode(riscv_enc_cmpxchgw_acq(res, mem, oldval, newval));
 
   ins_pipe(pipe_slow);
 %}
@@ -5426,7 +5426,7 @@ instruct compareAndSwapLAcq(iRegINoSp res, indirect mem, iRegLNoSp oldval, iRegL
     "mv $res, $res == $oldval\t# $res <-- ($res == $oldval ? 1 : 0), #@compareAndSwapLAcq"
   %}
 
-  ins_encode(riscv64_enc_cmpxchg_acq(res, mem, oldval, newval));
+  ins_encode(riscv_enc_cmpxchg_acq(res, mem, oldval, newval));
 
   ins_pipe(pipe_slow);
 %}
@@ -5444,7 +5444,7 @@ instruct compareAndSwapPAcq(iRegINoSp res, indirect mem, iRegP oldval, iRegP new
     "mv $res, $res == $oldval\t# $res <-- ($res == $oldval ? 1 : 0), #@compareAndSwapPAcq"
   %}
 
-  ins_encode(riscv64_enc_cmpxchg_acq(res, mem, oldval, newval));
+  ins_encode(riscv_enc_cmpxchg_acq(res, mem, oldval, newval));
 
   ins_pipe(pipe_slow);
 %}
@@ -5462,7 +5462,7 @@ instruct compareAndSwapNAcq(iRegINoSp res, indirect mem, iRegNNoSp oldval, iRegN
     "mv $res, $res == $oldval\t# $res <-- ($res == $oldval ? 1 : 0), #@compareAndSwapNAcq"
   %}
 
-  ins_encode(riscv64_enc_cmpxchgn_acq(res, mem, oldval, newval));
+  ins_encode(riscv_enc_cmpxchgn_acq(res, mem, oldval, newval));
 
   ins_pipe(pipe_slow);
 %}
@@ -6694,7 +6694,7 @@ instruct divI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   ins_cost(IDIVSI_COST);
   format %{ "divw  $dst, $src1, $src2\t#@divI"%}
 
-  ins_encode(riscv64_enc_divw(dst, src1, src2));
+  ins_encode(riscv_enc_divw(dst, src1, src2));
   ins_pipe(idiv_reg_reg);
 %}
 
@@ -6716,7 +6716,7 @@ instruct divL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   ins_cost(IDIVDI_COST);
   format %{ "div  $dst, $src1, $src2\t#@divL" %}
 
-  ins_encode(riscv64_enc_div(dst, src1, src2));
+  ins_encode(riscv_enc_div(dst, src1, src2));
   ins_pipe(ldiv_reg_reg);
 %}
 
@@ -6739,7 +6739,7 @@ instruct modI(iRegINoSp dst, iRegIorL2I src1, iRegIorL2I src2) %{
   ins_cost(IDIVSI_COST);
   format %{ "remw  $dst, $src1, $src2\t#@modI" %}
 
-  ins_encode(riscv64_enc_modw(dst, src1, src2));
+  ins_encode(riscv_enc_modw(dst, src1, src2));
   ins_pipe(ialu_reg_reg);
 %}
 
@@ -6750,7 +6750,7 @@ instruct modL(iRegLNoSp dst, iRegL src1, iRegL src2) %{
   ins_cost(IDIVDI_COST);
   format %{ "rem  $dst, $src1, $src2\t#@modL" %}
 
-  ins_encode(riscv64_enc_mod(dst, src1, src2));
+  ins_encode(riscv_enc_mod(dst, src1, src2));
   ins_pipe(ialu_reg_reg);
 %}
 
@@ -8663,7 +8663,7 @@ instruct branch(label lbl)
   ins_cost(BRANCH_COST);
   format %{ "j  $lbl\t#@branch" %}
 
-  ins_encode(riscv64_enc_j(lbl));
+  ins_encode(riscv_enc_j(lbl));
 
   ins_pipe(pipe_branch);
 %}
@@ -9613,7 +9613,7 @@ instruct far_cmpULtGe_reg_imm0_branch(cmpOpULtGe cmp, iRegI op1, immI0 zero, lab
 
   format %{ "j  $lbl if $cmp == ge\t#@far_cmpULtGe_reg_imm0_branch" %}
 
-  ins_encode(riscv64_enc_far_cmpULtGe_imm0_branch(cmp, op1, lbl));
+  ins_encode(riscv_enc_far_cmpULtGe_imm0_branch(cmp, op1, lbl));
 
   ins_pipe(pipe_cmpz_branch);
 %}
@@ -9628,7 +9628,7 @@ instruct far_cmpULtGe_reg_imm0_loop(cmpOpULtGe cmp, iRegI op1, immI0 zero, label
 
   format %{ "j  $lbl if $cmp == ge\t#@far_cmpULtGe_reg_imm0_loop" %}
 
-  ins_encode(riscv64_enc_far_cmpULtGe_imm0_branch(cmp, op1, lbl));
+  ins_encode(riscv_enc_far_cmpULtGe_imm0_branch(cmp, op1, lbl));
 
   ins_pipe(pipe_cmpz_branch);
 %}
@@ -9712,7 +9712,7 @@ instruct far_cmpULLtGe_reg_imm0_branch(cmpOpULtGe cmp, iRegL op1, immL0 zero, la
 
   format %{ "j  $lbl if $cmp == ge\t#@far_cmpULLtGe_reg_imm0_branch" %}
 
-  ins_encode(riscv64_enc_far_cmpULtGe_imm0_branch(cmp, op1, lbl));
+  ins_encode(riscv_enc_far_cmpULtGe_imm0_branch(cmp, op1, lbl));
 
   ins_pipe(pipe_cmpz_branch);
 %}
@@ -9727,7 +9727,7 @@ instruct far_cmpULLtGe_reg_imm0_loop(cmpOpULtGe cmp, iRegL op1, immL0 zero, labe
 
   format %{ "j  $lbl if $cmp == ge\t#@far_cmpULLtGe_reg_imm0_loop" %}
 
-  ins_encode(riscv64_enc_far_cmpULtGe_imm0_branch(cmp, op1, lbl));
+  ins_encode(riscv_enc_far_cmpULtGe_imm0_branch(cmp, op1, lbl));
 
   ins_pipe(pipe_cmpz_branch);
 %}
@@ -9950,8 +9950,8 @@ instruct CallStaticJavaDirect(method meth)
 
   format %{ "CALL,static $meth\t#@CallStaticJavaDirect" %}
 
-  ins_encode( riscv64_enc_java_static_call(meth),
-              riscv64_enc_call_epilog );
+  ins_encode(riscv_enc_java_static_call(meth),
+             riscv_enc_call_epilog);
 
   ins_pipe(pipe_class_call);
   ins_alignment(4);
@@ -9972,8 +9972,8 @@ instruct CallDynamicJavaDirect(method meth, rFlagsReg cr)
 
   format %{ "CALL,dynamic $meth\t#@CallDynamicJavaDirect" %}
 
-  ins_encode( riscv64_enc_java_dynamic_call(meth),
-              riscv64_enc_call_epilog );
+  ins_encode(riscv_enc_java_dynamic_call(meth),
+             riscv_enc_call_epilog);
 
   ins_pipe(pipe_class_call);
   ins_alignment(4);
@@ -9991,7 +9991,7 @@ instruct CallRuntimeDirect(method meth, rFlagsReg cr)
 
   format %{ "CALL, runtime $meth\t#@CallRuntimeDirect" %}
 
-  ins_encode( riscv64_enc_java_to_runtime(meth) );
+  ins_encode(riscv_enc_java_to_runtime(meth));
 
   ins_pipe(pipe_class_call);
 %}
@@ -10008,7 +10008,7 @@ instruct CallLeafDirect(method meth, rFlagsReg cr)
 
   format %{ "CALL, runtime leaf $meth\t#@CallLeafDirect" %}
 
-  ins_encode( riscv64_enc_java_to_runtime(meth) );
+  ins_encode(riscv_enc_java_to_runtime(meth));
 
   ins_pipe(pipe_class_call);
 %}
@@ -10025,7 +10025,7 @@ instruct CallLeafNoFPDirect(method meth, rFlagsReg cr)
 
   format %{ "CALL, runtime leaf nofp $meth\t#@CallLeafNoFPDirect" %}
 
-  ins_encode( riscv64_enc_java_to_runtime(meth) );
+  ins_encode(riscv_enc_java_to_runtime(meth));
 
   ins_pipe(pipe_class_call);
 %}
@@ -10046,7 +10046,7 @@ instruct partialSubtypeCheck(iRegP_R15 result, iRegP_R14 sub, iRegP_R10 super, i
   ins_cost(2 * STORE_COST + 3 * LOAD_COST + 4 * ALU_COST + BRANCH_COST * 4);
   format %{ "partialSubtypeCheck $result, $sub, $super\t#@partialSubtypeCheck" %}
 
-  ins_encode(riscv64_enc_partial_subtype_check(sub, super, tmp, result));
+  ins_encode(riscv_enc_partial_subtype_check(sub, super, tmp, result));
 
   opcode(0x1); // Force zero of result reg on hit
 
@@ -10062,7 +10062,7 @@ instruct partialSubtypeCheckVsZero(iRegP_R15 result, iRegP_R14 sub, iRegP_R10 su
   ins_cost(2 * STORE_COST + 3 * LOAD_COST + 4 * ALU_COST + BRANCH_COST * 4);
   format %{ "partialSubtypeCheck $result, $sub, $super == 0\t#@partialSubtypeCheckVsZero" %}
 
-  ins_encode(riscv64_enc_partial_subtype_check(sub, super, tmp, result));
+  ins_encode(riscv_enc_partial_subtype_check(sub, super, tmp, result));
 
   opcode(0x0); // Don't zero result reg on hit
 
@@ -10453,7 +10453,7 @@ instruct cmpFastLock(rFlagsReg cr, iRegP object, iRegP box, iRegPNoSp tmp1, iReg
   ins_cost(LOAD_COST * 2 + STORE_COST * 3 + ALU_COST * 6 + BRANCH_COST * 3);
   format %{ "fastlock $object,$box\t! kills $tmp1,$tmp2, #@cmpFastLock" %}
 
-  ins_encode(riscv64_enc_fast_lock(object, box, tmp1, tmp2));
+  ins_encode(riscv_enc_fast_lock(object, box, tmp1, tmp2));
 
   ins_pipe(pipe_serial);
 %}
@@ -10467,7 +10467,7 @@ instruct cmpFastUnlock(rFlagsReg cr, iRegP object, iRegP box, iRegPNoSp tmp1, iR
   ins_cost(LOAD_COST * 2 + STORE_COST + ALU_COST * 2 + BRANCH_COST * 4);
   format %{ "fastunlock $object,$box\t! kills $tmp1, $tmp2, #@cmpFastUnlock" %}
 
-  ins_encode(riscv64_enc_fast_unlock(object, box, tmp1, tmp2));
+  ins_encode(riscv_enc_fast_unlock(object, box, tmp1, tmp2));
 
   ins_pipe(pipe_serial);
 %}
@@ -10484,7 +10484,7 @@ instruct TailCalljmpInd(iRegPNoSp jump_target, inline_cache_RegP method_oop)
 
   format %{ "jalr $jump_target\t# $method_oop holds method oop, #@TailCalljmpInd." %}
 
-  ins_encode(riscv64_enc_tail_call(jump_target));
+  ins_encode(riscv_enc_tail_call(jump_target));
 
   ins_pipe(pipe_class_call);
 %}
@@ -10497,7 +10497,7 @@ instruct TailjmpInd(iRegPNoSp jump_target, iRegP_R10 ex_oop)
 
   format %{ "jalr $jump_target\t# $ex_oop holds exception oop, #@TailjmpInd." %}
 
-  ins_encode(riscv64_enc_tail_jmp(jump_target));
+  ins_encode(riscv_enc_tail_jmp(jump_target));
 
   ins_pipe(pipe_class_call);
 %}
@@ -10529,7 +10529,7 @@ instruct RethrowException()
 
   format %{ "j rethrow_stub\t#@RethrowException" %}
 
-  ins_encode( riscv64_enc_rethrow() );
+  ins_encode(riscv_enc_rethrow());
 
   ins_pipe(pipe_class_call);
 %}
@@ -10543,7 +10543,7 @@ instruct Ret()
   ins_cost(BRANCH_COST);
   format %{ "ret\t// return register, #@Ret" %}
 
-  ins_encode(riscv64_enc_ret());
+  ins_encode(riscv_enc_ret());
 
   ins_pipe(pipe_branch);
 %}

--- a/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
+++ b/src/hotspot/cpu/riscv/sharedRuntime_riscv.cpp
@@ -71,7 +71,7 @@ public:
     // The frame sender code expects that fp will be in the "natural" place and
     // will override any oopMap setting for it. We must therefore force the layout
     // so that it agrees with the frame sender code.
-    // we don't expect any arg reg save area so riscv64 asserts that
+    // we don't expect any arg reg save area so riscv asserts that
     // frame::arg_reg_save_area_bytes == 0
     fp_off = 0, fp_off2,
     return_off, return_off2,
@@ -685,7 +685,7 @@ int SharedRuntime::c_calling_convention(const BasicType *sig_bt,
                                          VMRegPair *regs,
                                          VMRegPair *regs2,
                                          int total_args_passed) {
-  assert(regs2 == NULL, "not needed on riscv64");
+  assert(regs2 == NULL, "not needed on riscv");
 
   // We return the amount of VMRegImpl stack slots we need to reserve for all
   // the arguments NOT counting out_preserve_stack_slots.
@@ -2199,7 +2199,7 @@ void SharedRuntime::generate_deopt_blob() {
 // Number of stack slots between incoming argument block and the start of
 // a new frame. The PROLOG must add this many slots to the stack. The
 // EPILOG must remove this many slots.
-// RISCV64 needs two words for RA (return address) and FP (frame pointer).
+// RISCV needs two words for RA (return address) and FP (frame pointer).
 uint SharedRuntime::in_preserve_stack_slots() {
   return 2 * VMRegImpl::slots_per_word;
 }

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -214,7 +214,7 @@ class StubGenerator: public StubCodeGenerator {
 
     // stub code
 
-    address riscv64_entry = __ pc();
+    address riscv_entry = __ pc();
 
     // set up frame and move sp to end of save area
     __ enter();

--- a/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
+++ b/src/hotspot/cpu/riscv/vtableStubs_riscv.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2003, 2018, Oracle and/or its affiliates. All rights reserved.
  * Copyright (c) 2014, Red Hat Inc. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -254,7 +254,7 @@ VtableStub* VtableStubs::create_itable_stub(int itable_index) {
 }
 
 int VtableStub::pd_code_alignment() {
-  // riscv64 cache line size is 64 bytes, but we want to limit alignment loss.
+  // riscv cache line size is 64 bytes, but we want to limit alignment loss.
   const unsigned int icache_line_size = wordSize;
   return icache_line_size;
 }

--- a/src/hotspot/os_cpu/linux_riscv/globals_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/globals_linux_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,8 +39,5 @@ define_pd_global(uintx, JVMInvokeMethodSlack,     8192);
 
 // Used on 64 bit platforms for UseCompressedOops base address
 define_pd_global(uintx, HeapBaseMinAddress,       2 * G);
-
-class Thread;
-extern __thread Thread *riscv64_currentThread;
 
 #endif // OS_CPU_LINUX_RISCV_VM_GLOBALS_LINUX_RISCV_HPP

--- a/src/hotspot/os_cpu/linux_riscv/thread_linux_riscv.hpp
+++ b/src/hotspot/os_cpu/linux_riscv/thread_linux_riscv.hpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
- * Copyright (c) 2020, 2021, Huawei Technologies Co., Ltd. All rights reserved.
+ * Copyright (c) 2020, 2022, Huawei Technologies Co., Ltd. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,8 +44,5 @@
   bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava);
 private:
   bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
-public:
-
-  static Thread *riscv64_get_thread_helper();
 
 #endif // OS_CPU_LINUX_RISCV_THREAD_LINUX_RISCV_HPP


### PR DESCRIPTION
This PR has the following changes:

- Remove unused code in linux_riscv
- More renaming from riscv64 to riscv in riscv backend

Hotspot and jdk tier1 tests on QEMU are passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282466](https://bugs.openjdk.java.net/browse/JDK-8282466): riscv: Remove unused code in linux_riscv


### Reviewers
 * [Yanhong Zhu](https://openjdk.java.net/census#yzhu) (@yhzhu20 - Committer)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/62/head:pull/62` \
`$ git checkout pull/62`

Update a local copy of the PR: \
`$ git checkout pull/62` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/62/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 62`

View PR using the GUI difftool: \
`$ git pr show -t 62`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/62.diff">https://git.openjdk.java.net/riscv-port/pull/62.diff</a>

</details>
