### PR TITLE
8282328: riscv: Intrinsify bigIntegerRightShift

### DIFF
--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2916,7 +2916,7 @@ class StubGenerator: public StubCodeGenerator {
   //
   address generate_bigIntegerRightShift() {
     __ align(CodeEntryAlignment);
-    StubCodeMark mark(this,  "StubRoutines", "bigIntegerRightShiftWorker");
+    StubCodeMark mark(this, "StubRoutines", "bigIntegerRightShiftWorker");
     address entry = __ pc();
 
     Label loop, exit;

--- a/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
+++ b/src/hotspot/cpu/riscv/stubGenerator_riscv.cpp
@@ -2904,6 +2904,60 @@ class StubGenerator: public StubCodeGenerator {
 
     return entry;
   }
+
+  // Arguments:
+  //
+  // Input:
+  //   c_rarg0   - newArr address
+  //   c_rarg1   - oldArr address
+  //   c_rarg2   - newIdx
+  //   c_rarg3   - shiftCount
+  //   c_rarg4   - numIter
+  //
+  address generate_bigIntegerRightShift() {
+    __ align(CodeEntryAlignment);
+    StubCodeMark mark(this,  "StubRoutines", "bigIntegerRightShiftWorker");
+    address entry = __ pc();
+
+    Label loop, exit;
+
+    Register newArr        = c_rarg0;
+    Register oldArr        = c_rarg1;
+    Register newIdx        = c_rarg2;
+    Register shiftCount    = c_rarg3;
+    Register numIter       = c_rarg4;
+    Register idx           = numIter;
+
+    Register shiftRevCount = c_rarg5;
+    Register oldArrNext    = c_rarg6;
+    Register newArrCur     = t0;
+    Register oldArrCur     = t1;
+
+    __ beqz(idx, exit);
+    __ shadd(newArr, newIdx, newArr, t0, 2);
+
+    __ li(shiftRevCount, 32);
+    __ sub(shiftRevCount, shiftRevCount, shiftCount);
+
+    __ bind(loop);
+    __ vsetvli(t0, idx, Assembler::e32, Assembler::m4);
+    __ sub(idx, idx, t0);
+    __ shadd(oldArrNext, idx, oldArr, t1, 2);
+    __ shadd(newArrCur, idx, newArr, t1, 2);
+    __ addi(oldArrCur, oldArrNext, 4);
+    __ vle32_v(v0, oldArrCur);
+    __ vle32_v(v4, oldArrNext);
+    __ vsrl_vx(v0, v0, shiftCount);
+    __ vsll_vx(v4, v4, shiftRevCount);
+    __ vor_vv(v0, v0, v4);
+    __ vse32_v(v0, newArrCur);
+    __ bnez(idx, loop);
+
+    __ bind(exit);
+    __ ret();
+
+    return entry;
+  }
 #endif
 
 #ifdef COMPILER2
@@ -3772,6 +3826,7 @@ class StubGenerator: public StubCodeGenerator {
 
     if (UseRVVForBigIntegerShiftIntrinsics) {
       StubRoutines::_bigIntegerLeftShiftWorker = generate_bigIntegerLeftShift();
+      StubRoutines::_bigIntegerRightShiftWorker = generate_bigIntegerRightShift();
     }
 #endif
 


### PR DESCRIPTION
BigInteger intrinsic: bigIntegerRightShift intrinsic is missed in current vm. It should be implemented.
Since that there is no hardware that supports rvv1.0 for now, I used test/jdk/java/math/BigInteger/ModPow.java testcase to compare the number of instructions executed with and without intrinsic. The number of instructions executed for the method shiftRightImplWorker compiled by C2 without intrinsic is about 8.6x ( vlen=256 ) that of version with intrinsic.

Full jtreg tests on qemu are passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282328](https://bugs.openjdk.java.net/browse/JDK-8282328): riscv: Intrinsify BigIntegerRightShift


### Reviewers
 * [Yanhong Zhu](https://openjdk.java.net/census#yzhu) (@yhzhu20 - Committer)
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/63.diff">https://git.openjdk.java.net/riscv-port/pull/63.diff</a>

</details>
