### PR TITLE
8282436: riscv: pd_disjoint_words_atomic() needs to be atomic

### DIFF
--- a/src/hotspot/cpu/riscv/copy_riscv.hpp
+++ b/src/hotspot/cpu/riscv/copy_riscv.hpp
@@ -57,7 +57,7 @@ static void pd_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) 
   (void)memmove(to, from, count * HeapWordSize);
 }
 
-static inline void pd_disjoint_words_helper(const HeapWord* from, HeapWord* to, size_t count, bool is_atomic) {
+static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
   switch (count) {
     case 8:  to[7] = from[7];   // fall through
     case 7:  to[6] = from[6];   // fall through
@@ -69,20 +69,13 @@ static inline void pd_disjoint_words_helper(const HeapWord* from, HeapWord* to, 
     case 1:  to[0] = from[0];   // fall through
     case 0:  break;
     default:
-      if (is_atomic) {
-        while (count-- > 0) { *to++ = *from++; }
-      } else {
-        memcpy(to, from, count * HeapWordSize);
-      }
+      memcpy(to, from, count * HeapWordSize);
+      break;
   }
 }
 
-static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
-  pd_disjoint_words_helper(from, to, count, false);
-}
-
 static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
-  pd_disjoint_words_helper(from, to, count, true);
+  shared_disjoint_words_atomic(from, to, count);
 }
 
 static void pd_aligned_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {


### PR DESCRIPTION
With reference to https://bugs.openjdk.java.net/browse/JDK-8227369, there is the same issue on the riscv platform

Full jtreg tests on qemu and hotspot/jdk tier1 test on Unmathced are passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8282436](https://bugs.openjdk.java.net/browse/JDK-8282436): riscv: pd_disjoint_words_atomic() needs to be atomic


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)
 * [Yanhong Zhu](https://openjdk.java.net/census#yzhu) (@yhzhu20 - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/64.diff">https://git.openjdk.java.net/riscv-port/pull/64.diff</a>

</details>
