### PR TITLE
8283020: riscv: Fix configure integration

### DIFF
--- a/make/autoconf/build-aux/autoconf-config.guess
+++ b/make/autoconf/build-aux/autoconf-config.guess
@@ -1,6 +1,6 @@
 #! /bin/sh
 #
-# Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -999,9 +999,6 @@ EOF
 	exit ;;
     ppc:Linux:*:*)
 	echo powerpc-unknown-linux-gnu
-	exit ;;
-    riscv64:Linux:*:*)
-	echo riscv64-unknown-linux-gnu
 	exit ;;
     s390:Linux:*:* | s390x:Linux:*:*)
 	echo ${UNAME_MACHINE}-ibm-linux

--- a/make/autoconf/build-aux/autoconf-config.sub
+++ b/make/autoconf/build-aux/autoconf-config.sub
@@ -1,7 +1,7 @@
 #! /bin/sh
 
 #
-# Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
 # DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 #
 # This code is free software; you can redistribute it and/or modify it
@@ -302,7 +302,6 @@ case $basic_machine in
 	| pdp10 | pdp11 | pj | pjl \
 	| powerpc | powerpc64 | powerpc64le | powerpcle | ppcbe \
 	| pyramid \
-	| riscv64 \
 	| score \
 	| sh | sh[1234] | sh[24]a | sh[23]e | sh[34]eb | sheb | shbe | shle | sh[1234]le | sh3ele \
 	| sh64 | sh64le \
@@ -384,7 +383,6 @@ case $basic_machine in
 	| pdp10-* | pdp11-* | pj-* | pjl-* | pn-* | power-* \
 	| powerpc-* | powerpc64-* | powerpc64le-* | powerpcle-* | ppcbe-* \
 	| pyramid-* \
-	| riscv64-* \
 	| romp-* | rs6000-* \
 	| sh-* | sh[1234]-* | sh[24]a-* | sh[23]e-* | sh[34]eb-* | sheb-* | shbe-* \
 	| shle-* | sh[1234]le-* | sh3ele-* | sh64-* | sh64le-* \

--- a/make/autoconf/build-aux/config.guess
+++ b/make/autoconf/build-aux/config.guess
@@ -111,6 +111,15 @@ if [ "x$OUT" = x ]; then
   fi
 fi
 
+# Test and fix RISC-V.
+if [ "x$OUT" = x ]; then
+  if [ `uname -s` = Linux ]; then
+    if [ `uname -m` = riscv64 ]; then
+      OUT=riscv64-unknown-linux-gnu
+    fi
+  fi
+fi
+
 # Test and fix cpu on macos-aarch64, uname -p reports arm, buildsys expects aarch64
 echo $OUT | grep arm-apple-darwin > /dev/null 2> /dev/null
 if test $? != 0; then

--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -343,7 +343,7 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_ZGC],
         AVAILABLE=false
       fi
     elif test "x$OPENJDK_TARGET_CPU" = "xppc64le" || \
-          test "x$OPENJDK_TARGET_CPU" = "xriscv64"; then
+        test "x$OPENJDK_TARGET_CPU" = "xriscv64"; then
       if test "x$OPENJDK_TARGET_OS" = "xlinux"; then
         AC_MSG_RESULT([yes])
       else


### PR DESCRIPTION
The current implementation in the riscv-port modifies make/autoconf/build-aux/autoconf-* files. For legal reasons, this is not something that is allowed. Instead, we need to introduce patches in our wrapper scripts in the same directory.

This patch will restore the original contents of the autoconf-* files, and instead move this logic to the wrapper scripts. 

This PR also fixes an indentation problem in configure.

I have not been able to verify this patch, since I do not have access to riscv hardware. I believe it is sufficient and correct, but it might be the case that config.sub also needs updating. I kindly request assistance in verifying this.

(Apart from these fixes, all build changes in the riscv-port looks good to me)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283020](https://bugs.openjdk.java.net/browse/JDK-8283020): riscv: Fix configure integration


### Reviewers
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)
 * [Feilong Jiang](https://openjdk.java.net/census#fjiang) (@feilongjiang - Author)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/66/head:pull/66` \
`$ git checkout pull/66`

Update a local copy of the PR: \
`$ git checkout pull/66` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/66/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 66`

View PR using the GUI difftool: \
`$ git pr show -t 66`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/66.diff">https://git.openjdk.java.net/riscv-port/pull/66.diff</a>

</details>
