### PR TITLE
8283364: riscv: Intrinsify countPositives

### DIFF
--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.cpp
@@ -1542,6 +1542,34 @@ void C2_MacroAssembler::encode_iso_array_v(Register src, Register dst, Register 
   BLOCK_COMMENT("} encode_iso_array_v");
 }
 
+void C2_MacroAssembler::count_positives_v(Register ary, Register len, Register result, Register tmp) {
+  Label LOOP, SET_RESULT, DONE;
+
+  BLOCK_COMMENT("count_positives_v {");
+  mv(result, zr);
+
+  bind(LOOP);
+  vsetvli(t0, len, Assembler::e8, Assembler::m4);
+  vle8_v(v0, ary);
+  vmslt_vx(v0, v0, zr);
+  vfirst_m(tmp, v0);
+  bgez(tmp, SET_RESULT);
+  // if tmp == -1, all bytes are positive
+  add(result, result, t0);
+
+  sub(len, len, t0);
+  add(ary, ary, t0);
+  bnez(len, LOOP);
+  j(DONE);
+
+  // add remaining positive bytes count
+  bind(SET_RESULT);
+  add(result, result, tmp);
+
+  bind(DONE);
+  BLOCK_COMMENT("} count_positives_v");
+}
+
 void C2_MacroAssembler::string_indexof_char_v(Register str1, Register cnt1,
                                               Register ch, Register result,
                                               Register tmp1, Register tmp2,

--- a/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
+++ b/src/hotspot/cpu/riscv/c2_MacroAssembler_riscv.hpp
@@ -173,6 +173,9 @@
                          Register len, Register result,
                          Register tmp);
 
+ void count_positives_v(Register ary, Register len,
+                        Register result, Register tmp);
+
  void string_indexof_char_v(Register str1, Register cnt1,
                             Register ch, Register result,
                             Register tmp1, Register tmp2,

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1993,6 +1993,20 @@ instruct vstring_compress(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10
   ins_pipe( pipe_slow );
 %}
 
+instruct vcount_positives(iRegP_R11 ary1, iRegI_R12 len, iRegI_R10 result, iRegL tmp)
+%{
+  predicate(UseRVV);
+  match(Set result (CountPositives ary1 len));
+  effect(USE_KILL ary1, USE_KILL len, TEMP tmp);
+
+  format %{ "count positives byte[] $ary1, $len -> $result" %}
+  ins_encode %{
+    __ count_positives_v($ary1$$Register, $len$$Register, $result$$Register, $tmp$$Register);
+  %}
+
+  ins_pipe(pipe_slow);
+%}
+
 instruct vstringU_indexof_char(iRegP_R11 str1, iRegI_R12 cnt1, iRegI_R13 ch,
                                iRegI_R10 result, iRegINoSp tmp1, iRegINoSp tmp2,
                                vReg_V1 v1, vReg_V2 v2, vReg_V3 v3)

--- a/src/hotspot/cpu/riscv/riscv_v.ad
+++ b/src/hotspot/cpu/riscv/riscv_v.ad
@@ -1993,15 +1993,15 @@ instruct vstring_compress(iRegP_R12 src, iRegP_R11 dst, iRegI_R13 len, iRegI_R10
   ins_pipe( pipe_slow );
 %}
 
-instruct vcount_positives(iRegP_R11 ary1, iRegI_R12 len, iRegI_R10 result, iRegL tmp)
+instruct vcount_positives(iRegP_R11 ary, iRegI_R12 len, iRegI_R10 result, iRegL tmp)
 %{
   predicate(UseRVV);
-  match(Set result (CountPositives ary1 len));
-  effect(USE_KILL ary1, USE_KILL len, TEMP tmp);
+  match(Set result (CountPositives ary len));
+  effect(USE_KILL ary, USE_KILL len, TEMP tmp);
 
-  format %{ "count positives byte[] $ary1, $len -> $result" %}
+  format %{ "count positives byte[] $ary, $len -> $result" %}
   ins_encode %{
-    __ count_positives_v($ary1$$Register, $len$$Register, $result$$Register, $tmp$$Register);
+    __ count_positives_v($ary$$Register, $len$$Register, $result$$Register, $tmp$$Register);
   %}
 
   ins_pipe(pipe_slow);


### PR DESCRIPTION
[JDK-8281146](https://bugs.openjdk.java.net/browse/JDK-8281146) replaces `StringCoding.hasNegatives` with `countPositives` and introduces `Op_CountPositives`, which can be intrinsified on riscv port.

New added test test/hotspot/jtreg/compiler/intrinsics/string/TestCountPositives.java passed on QEMU with RVV enabled.

hotspot and jdk tier1 tests on QEMU with UseRVV enabled are passed without new failures.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change must be properly reviewed

### Issue
 * [JDK-8283364](https://bugs.openjdk.java.net/browse/JDK-8283364): riscv: Intrinsify countPositives


### Reviewers
 * [Yanhong Zhu](https://openjdk.java.net/census#yzhu) (@yhzhu20 - Committer) ⚠️ Review applies to 8cd6db6c7fe6a07234c6dc40dee9ec3ae52991dc
 * [Fei Yang](https://openjdk.java.net/census#fyang) (@RealFYang - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/67/head:pull/67` \
`$ git checkout pull/67`

Update a local copy of the PR: \
`$ git checkout pull/67` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/67/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 67`

View PR using the GUI difftool: \
`$ git pr show -t 67`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/67.diff">https://git.openjdk.java.net/riscv-port/pull/67.diff</a>

</details>
