### PR TITLE
Add Zero support for 32-bit RISC-V

### DIFF
--- a/make/autoconf/libraries.m4
+++ b/make/autoconf/libraries.m4
@@ -144,7 +144,8 @@ AC_DEFUN_ONCE([LIB_SETUP_LIBRARIES],
          test "x$OPENJDK_TARGET_CPU" = xmips ||
          test "x$OPENJDK_TARGET_CPU" = xmipsel ||
          test "x$OPENJDK_TARGET_CPU" = xppc ||
-         test "x$OPENJDK_TARGET_CPU" = xsh); then
+         test "x$OPENJDK_TARGET_CPU" = xsh ||
+         test "x$OPENJDK_TARGET_CPU" = xriscv32); then
       BASIC_JVM_LIBS="$BASIC_JVM_LIBS -latomic"
     fi
   fi

--- a/make/autoconf/platform.m4
+++ b/make/autoconf/platform.m4
@@ -126,6 +126,12 @@ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_CPU],
       VAR_CPU_BITS=64
       VAR_CPU_ENDIAN=little
       ;;
+    riscv32)
+      VAR_CPU=riscv32
+      VAR_CPU_ARCH=riscv
+      VAR_CPU_BITS=32
+      VAR_CPU_ENDIAN=little
+      ;;
     riscv64)
       VAR_CPU=riscv64
       VAR_CPU_ARCH=riscv
@@ -561,6 +567,8 @@ AC_DEFUN([PLATFORM_SETUP_LEGACY_VARS_HELPER],
     HOTSPOT_$1_CPU_DEFINE=PPC64
   elif test "x$OPENJDK_$1_CPU" = xppc64le; then
     HOTSPOT_$1_CPU_DEFINE=PPC64
+  elif test "x$OPENJDK_$1_CPU" = xriscv32; then
+    HOTSPOT_$1_CPU_DEFINE=RISCV32
   elif test "x$OPENJDK_$1_CPU" = xriscv64; then
     HOTSPOT_$1_CPU_DEFINE=RISCV64
 

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1628,7 +1628,7 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     {EM_PARISC,      EM_PARISC,  ELFCLASS32, ELFDATA2MSB, (char*)"PARISC"},
     {EM_68K,         EM_68K,     ELFCLASS32, ELFDATA2MSB, (char*)"M68k"},
     {EM_AARCH64,     EM_AARCH64, ELFCLASS64, ELFDATA2LSB, (char*)"AARCH64"},
-    {EM_RISCV,       EM_RISCV,   ELFCLASS64, ELFDATA2LSB, (char*)"RISC-V"},
+    {EM_RISCV,       EM_RISCV,   LP64_ONLY(ELFCLASS64) NOT_LP64(ELFCLASS32), ELFDATA2LSB, (char*)"RISC-V"},
     {EM_LOONGARCH,   EM_LOONGARCH, ELFCLASS64, ELFDATA2LSB, (char*)"LoongArch"},
   };
 
@@ -2497,7 +2497,7 @@ void os::get_summary_cpu_info(char* cpuinfo, size_t length) {
 #elif defined(PPC)
   strncpy(cpuinfo, "PPC64", length);
 #elif defined(RISCV)
-  strncpy(cpuinfo, "RISCV64", length);
+  strncpy(cpuinfo, LP64_ONLY("RISCV64") NOT_LP64("RISCV32"), length);
 #elif defined(S390)
   strncpy(cpuinfo, "S390", length);
 #elif defined(SPARC)

--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -1628,7 +1628,11 @@ void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
     {EM_PARISC,      EM_PARISC,  ELFCLASS32, ELFDATA2MSB, (char*)"PARISC"},
     {EM_68K,         EM_68K,     ELFCLASS32, ELFDATA2MSB, (char*)"M68k"},
     {EM_AARCH64,     EM_AARCH64, ELFCLASS64, ELFDATA2LSB, (char*)"AARCH64"},
-    {EM_RISCV,       EM_RISCV,   LP64_ONLY(ELFCLASS64) NOT_LP64(ELFCLASS32), ELFDATA2LSB, (char*)"RISC-V"},
+#ifdef _LP64
+    {EM_RISCV,       EM_RISCV,   ELFCLASS64, ELFDATA2LSB, (char*)"RISCV64"},
+#else
+    {EM_RISCV,       EM_RISCV,   ELFCLASS32, ELFDATA2LSB, (char*)"RISCV32"},
+#endif
     {EM_LOONGARCH,   EM_LOONGARCH, ELFCLASS64, ELFDATA2LSB, (char*)"LoongArch"},
   };
 

--- a/src/hotspot/os/linux/waitBarrier_linux.cpp
+++ b/src/hotspot/os/linux/waitBarrier_linux.cpp
@@ -38,6 +38,13 @@
 
 #define guarantee_with_errno(cond, msg) check_with_errno(guarantee, cond, msg)
 
+// 32-bit RISC-V doesn't have SYS_futex syscall.
+#ifndef SYS_futex
+  #if defined(RISCV32) && defined(SYS_futex_time64)
+    #define SYS_futex SYS_futex_time64
+  #endif
+#endif
+
 static int futex(volatile int *addr, int futex_op, int op_arg) {
   return syscall(SYS_futex, addr, futex_op, op_arg, NULL, NULL, 0);
 }

--- a/src/hotspot/os/linux/waitBarrier_linux.cpp
+++ b/src/hotspot/os/linux/waitBarrier_linux.cpp
@@ -38,7 +38,7 @@
 
 #define guarantee_with_errno(cond, msg) check_with_errno(guarantee, cond, msg)
 
-// 32-bit RISC-V doesn't have SYS_futex syscall.
+// 32-bit RISC-V has no SYS_futex syscall.
 #ifndef SYS_futex
   #if defined(RISCV32) && defined(SYS_futex_time64)
     #define SYS_futex SYS_futex_time64


### PR DESCRIPTION
This patch adds Zero support for the 32-bit RISC-V architecture.

It has been successfully cross-compiled:

```bash
$ qemu-riscv32 -L /path/to/riscv32/sysroot /path/to/riscv-port/openjdk-19-internal/bin/java --version
openjdk 19-internal 2022-09-20
OpenJDK Runtime Environment (build 19-internal-adhoc.xiejunfeng.riscv-port)
OpenJDK Zero VM (build 19-internal-adhoc.xiejunfeng.riscv-port, interpreted mode)
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Commit message must refer to an issue
- [ ] Change must be properly reviewed

### Error
&nbsp;⚠️ OCA signatory status must be verified

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/riscv-port pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.java.net/riscv-port pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/riscv-port/pull/68.diff">https://git.openjdk.java.net/riscv-port/pull/68.diff</a>

</details>
